### PR TITLE
Fix silent event loss & absent-value filters; add license/packaging/CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install test dependencies
+        # The unit tests exercise the package directly and do not require the
+        # MCP SDK (compat.py falls back to mock objects when it is absent).
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest lxml
+
+      - name: Run tests (with lxml)
+        run: pytest -q
+
+      - name: Run tests (stdlib ElementTree fallback)
+        run: |
+          pip uninstall -y lxml
+          pytest -q

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,11 @@ venv/
 # Exported data
 exports/
 
+# Local Procmon captures (may contain sensitive data — never commit)
+captures/
+*.PML
+*.pml
+
 # IDE
 .idea/
 .vscode/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 JameZUK
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ cd ProcmonMCP
 pip install -r requirements.txt
 ```
 
+Or install the package itself (provides a `procmon-mcp` console script):
+
+```bash
+pip install .            # core only (mcp[cli])
+pip install ".[all]"     # core + optional lxml and psutil
+pip install -e ".[dev]"  # editable install with test tooling
+```
+
 ### Dependencies
 
 | Package | Required | Purpose |
@@ -364,3 +372,7 @@ For filters not backed by an index (e.g., regex, path contains, stack module pat
 ## Contributing
 
 Contributions are welcome! Please feel free to submit pull requests or open issues on [GitHub](https://github.com/JameZUK/ProcmonMCP).
+
+## License
+
+This project is licensed under the MIT License — see the [LICENSE](LICENSE) file for details.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,169 +1,84 @@
-# ProcmonMCP - Project Review
+# ProcmonMCP — Project Review
+
+> This review reflects the modular `procmon_mcp` package (post-refactor). An
+> earlier review of the original single-file `procmon-mcp.py` has been
+> superseded; its findings were either addressed by the package split or are
+> tracked below.
 
 ## Summary
 
-ProcmonMCP is a Model Context Protocol (MCP) server (single Python file, ~2300 lines) that enables LLMs to autonomously analyze Process Monitor (Procmon) XML log files. The project loads a Procmon XML file into memory with string interning and index optimizations, then exposes 14 MCP tools for querying events, inspecting processes, and exporting results.
-
-The project is functional and demonstrates solid domain knowledge of both the MCP protocol and Procmon data analysis. The review below covers architecture, code quality, security, performance, testing, and packaging.
-
----
-
-## 1. Architecture & Design
-
-**Strengths:**
-- Two-pass XML parsing (processes first, then events) is well-designed for building the process lookup table before event enrichment.
-- String interning via `StringInterner` is an effective memory optimization for repetitive Procmon data (process names, operations, paths, results).
-- Pre-built indices for process name and operation enable fast filtering without full scans.
-- Compression support (gzip, bz2, lzma) adds practical flexibility.
-- Graceful fallbacks (lxml -> stdlib ElementTree, psutil optional, MCP SDK mock) are pragmatic.
-
-**Concerns:**
-- **Single-file monolith (2303 lines):** The entire server—data structures, XML parsing, MCP tool definitions, filtering engine, export logic, CLI entry point—lives in one file. Splitting into modules (e.g., `models.py`, `parser.py`, `tools.py`, `filters.py`) would improve navigability and testability.
-- **Global mutable state:** `LOADED_DATA` is a module-level global modified by `main_execution()` and read by all MCP tool handlers. This makes unit testing difficult and prevents running multiple server instances in-process. Consider dependency injection or a server context object.
-- **Single-file limitation:** Only one Procmon file can be loaded per server instance. This is documented but architecturally baked in through the global state pattern.
+ProcmonMCP is a Model Context Protocol (MCP) server that lets an LLM analyse
+Process Monitor (Procmon) XML captures. The codebase is split into focused
+modules (`compat`, `constants`, `helpers`, `models`, `parser`, `filters`,
+`formatters`, `server`, `tools`, `cli`, `config`) with string interning and four
+indices (process name, operation, PID, path) for fast lookups, graceful
+fallbacks (lxml → stdlib ElementTree, optional psutil/MCP SDK), and a unit-test
+suite. It is functional and demonstrates solid domain knowledge of both MCP and
+Procmon analysis.
 
 ---
 
-## 2. Code Quality
+## Findings addressed in this pass
 
-### Formatting & Style
-- **Semicolons as statement separators** are used extensively (e.g., `procmon-mcp.py:92-96`, `procmon-mcp.py:461`, `procmon-mcp.py:1583`), placing multiple statements on a single line. This reduces readability. Standard Python style uses one statement per line.
-- **Inconsistent line lengths:** Some lines exceed 200 characters, making the code difficult to read without horizontal scrolling.
-- **Commented-out code:** Dead code blocks remain in `_clear_elem()` (`procmon-mcp.py:178-188`) and `StringInterner.get_id()` (`procmon-mcp.py:213-218`). These should be removed; version control preserves history.
+### Critical — silent event loss/corruption on large files (fixed)
 
-### Specific Issues
+`parser._parse_xml_stream_for_loading` previously extracted every event field on
+the iterparse **`start`** event of `<event>`. `iterparse` does not guarantee an
+element's children/text are populated at `start` (only at `end`), so whenever a
+read-buffer boundary fell inside an `<event>`, that event was silently dropped
+or kept with null `Operation`/`Path`/`Result`. Reproduced on a 20,000-event
+capture: ~0.5% of events were lost and dozens more were corrupted, in both the
+lxml and stdlib paths.
 
-1. **Duplicate `io` import** (`procmon-mcp.py:7` and `procmon-mcp.py:26`): `import io` and `import io as pstats_io` import the same module twice under different names. Use `io.StringIO` directly instead.
-
-2. **`StopAsyncIteration` raised inside async generator** (`procmon-mcp.py:1018`, `1021`): Per PEP 479 (enforced in Python 3.7+), raising `StopIteration` or `StopAsyncIteration` inside a generator body is converted to `RuntimeError`. The correct pattern is to simply `return` from the generator:
-   ```python
-   # Current (problematic):
-   raise StopAsyncIteration("Log data not loaded.")
-
-   # Should be:
-   await ctx.error("Filtering failed: Log data not loaded.")
-   return
-   ```
-
-3. **`exit()` vs `sys.exit()`** (`procmon-mcp.py:2158`, `2179`, `2182`, etc.): The built-in `exit()` is intended for the interactive interpreter. Use `sys.exit()` in scripts for clarity and reliability.
-
-4. **CSV export mutates dictionaries** (`procmon-mcp.py:2113-2115`): `export_query_results` converts `extra_data`, `stack_trace`, and `process_details_summary` to JSON strings in-place on the `row_dict` returned by `_get_formatted_event_details`. While these are temporary copies in practice, mutating dicts during iteration is a code smell. Create copies or use a serialization helper.
-
-5. **`iterparse` `tag` parameter compatibility** (`procmon-mcp.py:408`, `498`): The `tag` keyword argument to `iterparse` is not supported in the same way across all Python/lxml versions. In CPython's `xml.etree.ElementTree`, `tag` support in `iterparse` was not available until Python 3.13. This could cause `TypeError` on older Python versions despite the 3.7+ minimum claim.
-
-6. **Process list parsing state machine** (`procmon-mcp.py:421-427`): The state transitions from `seeking_procmon` to `seeking_processlist` on *any* end-event that isn't `procmon`. If the XML has unexpected top-level elements, this could skip the processlist or misparse. A more robust approach would check for the `processlist` start tag explicitly.
-
-7. **README typo** (`README.md:97`): "To use GhidraMCP with Cline" should read "To use ProcmonMCP with Cline".
-
----
-
-## 3. Security
-
-### Well-Handled
-- **Path traversal prevention** in `export_query_results` (`procmon-mcp.py:2011-2042`) uses `os.path.commonpath` to ensure output files stay within the working directory. This is correctly implemented.
-- **Security warning** in the README is prominent and detailed.
-
-### Concerns
-
-1. **No authentication on SSE transport:** When using `--transport sse`, the server binds to a network interface and accepts unauthenticated connections. Any process or user that can reach the host:port has full read access to all loaded Procmon data. The README warns about trusted environments, but the server could at minimum support a shared secret or API key.
-
-2. **Regex Denial of Service (ReDoS):** User-supplied regex patterns (`filter_path_regex`, `filter_process_regex`, `filter_detail_regex`) are compiled and executed against potentially millions of events with no timeout or complexity limit (`procmon-mcp.py:1027-1029`). A pathological regex like `(a+)+$` could hang the server. Consider using `re2` or adding a timeout wrapper.
-
-3. **No input length limits on filter parameters:** String filter parameters have no maximum length validation. Extremely long strings could cause memory or performance issues during filtering.
-
-4. **`os.makedirs` in export** (`procmon-mcp.py:2032`): While the path traversal check prevents writing outside CWD, the `os.makedirs` call allows creating arbitrary directory structures within CWD. This is low-risk but worth noting.
-
----
-
-## 4. Performance
-
-**Strengths:**
-- String interning significantly reduces memory for repetitive data.
-- Pre-built indices for `pname_id` and `op_id` enable O(1) lookup of candidate event sets before applying further filters.
-- Stream-based XML parsing (`iterparse`) keeps peak memory manageable during loading.
-- Progress reporting during long operations provides good user feedback.
-- The optimization decision to use direct element iteration over lxml XPath (`procmon-mcp.py:163-169`) is well-documented with profiling justification.
-
-**Improvement Opportunities:**
-
-1. **`count_events_by_process`** (`procmon-mcp.py:1620-1662`) iterates all events and resolves string names, when it could use the existing `pname_id_index` directly:
-   ```python
-   # Could be:
-   for pname_id, event_indices in log_data.pname_id_index.items():
-       name = log_data.get_string(IK_PROCESS_NAME, pname_id) or 'Unknown'
-       event_counts[name] = len(event_indices)
-   ```
-   This would be O(unique_names) instead of O(total_events).
-
-2. **`get_process_lifetime`** (`procmon-mcp.py:1816-1852`) performs a full linear scan of all events. It could use the `pname_id_index` to narrow the search to events for the specific process, then further filter by operation using `op_id_index` intersection.
-
-3. **Sorting `candidate_indices`** (`procmon-mcp.py:1103`): Converting a set to a sorted list for "cache locality" adds O(n log n) overhead. For large candidate sets, this overhead may exceed any cache benefit. Profiling should validate whether this helps.
-
-4. **`find_file_access`** does a full linear scan with no index support. For a frequently used analysis tool, a path-based index (even a simple substring trie) could help.
-
----
-
-## 5. Testing
-
-**Current state:** The project has a single integration test file (`tests/procmon-mcp-tester.py`) that:
-- Requires a running MCP server with loaded data
-- Only supports SSE transport (not stdio)
-- Performs smoke tests by calling each tool and printing results
-- Has no assertions or pass/fail criteria
-- Has no test data fixtures
-
-**Recommendations:**
-- Add **unit tests** for core components: `StringInterner`, `ProcessInfo.from_xml_element`, `_parse_timestamp_str`, `_strip_namespace`, `_find_text_ignore_ns`, time filter parsing.
-- Add **integration tests** with small sample XML fixtures that can run without a full MCP server.
-- Add a **test runner** configuration (pytest) and consider CI integration.
-- Create **sample Procmon XML test files** (small, synthetic) for reproducible testing.
-
----
-
-## 6. Packaging & Distribution
-
-**Missing files:**
-- No `requirements.txt` or `pyproject.toml` — dependencies are only documented in the README. Users must manually install `mcp[cli]`, `lxml`, and `psutil`.
-- No `.gitignore` — risks committing `.prof` files, `__pycache__`, IDE configs, exported CSV/JSON files, etc.
-- No `setup.py` or packaging metadata — the project can't be installed via pip.
-- No Dockerfile — could simplify deployment, especially for SSE transport mode.
-- No license file.
-
----
-
-## 7. Midnight Rollover Handling
-
-The timestamp rollover logic (`procmon-mcp.py:566-568`) advances the date when a parsed time is less than the previous time. This is documented but fragile:
-- A single out-of-order event (common in multi-threaded Procmon captures) could trigger a false rollover, advancing the date permanently for all subsequent events.
-- There is no mechanism to detect or recover from false rollovers.
-- Consider requiring a minimum time gap (e.g., the new time must be significantly earlier, like > 1 hour earlier) before triggering a rollover.
-
----
-
-## 8. Summary of Findings by Severity
-
-### High
-| # | Finding | Location |
-|---|---------|----------|
-| 1 | `StopAsyncIteration` raised inside async generator causes `RuntimeError` | `procmon-mcp.py:1018,1021` |
-| 2 | `iterparse` `tag` parameter not supported in stdlib before Python 3.13 | `procmon-mcp.py:408,498` |
-| 3 | No authentication on SSE transport | `procmon-mcp.py:2187-2198` |
+**Fix:** all field extraction (including stack frames, read from the event's
+fully-parsed `<stack>` subtree) now happens on the `<event>` **end** event —
+matching how Pass 1 already parses `<process>` elements. A regression test
+(`TestParserIntegration`) loads a 20,000-event capture and asserts zero drops,
+zero null core fields, and complete stacks, under both XML backends.
 
 ### Medium
-| # | Finding | Location |
-|---|---------|----------|
-| 4 | ReDoS risk with user-supplied regex patterns | `procmon-mcp.py:1027-1029` |
-| 5 | Fragile midnight rollover detection | `procmon-mcp.py:566-568` |
-| 6 | No `requirements.txt` or packaging metadata | Project root |
-| 7 | No `.gitignore` file | Project root |
-| 8 | No unit tests | `tests/` |
+
+- **`requirements.txt` vs docs (fixed):** the file pinned `lxml` and `psutil`
+  as hard requirements while the README/`compat.py` treat them as optional. It
+  now lists only `mcp[cli]` as required and documents the optional extras.
+- **Packaging metadata (fixed):** added `pyproject.toml` (setuptools) with a
+  `procmon-mcp` console script and `lxml`/`psutil`/`all`/`dev` optional extras.
+  Added a `LICENSE` (MIT) and a CI workflow that runs the tests on Python
+  3.10–3.13 with and without lxml.
 
 ### Low
-| # | Finding | Location |
-|---|---------|----------|
-| 9 | Duplicate `io` import | `procmon-mcp.py:7,26` |
-| 10 | `exit()` instead of `sys.exit()` | Multiple locations |
-| 11 | CSV export mutates source dictionaries | `procmon-mcp.py:2113-2115` |
-| 12 | README references "GhidraMCP" instead of "ProcmonMCP" | `README.md:97` |
-| 13 | Semicolons reduce readability | Throughout |
-| 14 | `count_events_by_process` could use existing index | `procmon-mcp.py:1641` |
+
+- **`query_events` exception handling (fixed):** removed a redundant
+  `isinstance` re-check that double-wrapped `RuntimeError`s; meaningful errors
+  are now re-raised as-is.
+- **`export_query_results` ordering (fixed):** it now verifies a file is loaded
+  *before* validating the output path and creating directories.
+- **`find_network_connections` endpoint parsing (fixed):** the inline regex
+  matched only IP/hex hosts despite a docstring promising "Hostname:port". It is
+  now a tested helper (`helpers.parse_network_endpoint`) covering IPv4, bracketed
+  IPv6, and DNS hostnames.
+
+---
+
+## Notes / possible future work
+
+- **Global mutable state:** `server.LOADED_DATA` / `LOADING_IN_PROGRESS` are
+  module-level globals. A single async load guard makes this safe in practice,
+  but a server-context object would ease testing and multi-instance use.
+- **Single file at a time:** loading a new capture replaces the previous one.
+  Documented and intentional.
+- **ReDoS:** user-supplied regex filters are length-capped (`MAX_REGEX_LEN`) but
+  not time-bounded. A pathological pattern over millions of events could still
+  be slow; a `re2`/timeout wrapper would harden this.
+- **Network/SSE transport:** HTTP/SSE transports are unauthenticated. The README
+  warns to run only in trusted environments; a shared-secret option would help
+  for networked deployments.
+- **Midnight rollover:** date advancement uses a 1-hour out-of-order threshold,
+  which is reasonable but still heuristic for unusual captures.
+
+## Testing
+
+`pytest -q` — unit tests cover `StringInterner`, XML helpers, timestamp parsing,
+`ProcessInfo`, `ProcmonLogData`, config, network-endpoint parsing, and full
+parser integration (including the large-file regression). All pass under both
+lxml and the stdlib ElementTree fallback.

--- a/procmon_mcp/__init__.py
+++ b/procmon_mcp/__init__.py
@@ -18,7 +18,7 @@ from .constants import (
 from .helpers import (
     _compile_safe_regex, _strip_namespace, _find_child_ignore_ns,
     _find_text_ignore_ns, find_text_func, _clear_elem,
-    _parse_timestamp_str, _format_bytes,
+    _parse_timestamp_str, _format_bytes, parse_network_endpoint,
 )
 
 # Data models

--- a/procmon_mcp/filters.py
+++ b/procmon_mcp/filters.py
@@ -101,10 +101,33 @@ async def _iter_filtered_event_indices(
             await ctx.error(f"Invalid time filter: {e}")
             raise e
 
-        # Get interned IDs for exact match filters
-        process_id_filter = log_data.get_id(IK_PROCESS_NAME, filter_process) if filter_process else None
-        operation_id_filter = log_data.get_id(IK_OPERATION, filter_operation) if filter_operation else None
-        result_id_filter = log_data.get_id(IK_RESULT, filter_result) if filter_result else None
+        # Get interned IDs for exact match filters. A filter that was supplied
+        # but whose value is absent from the interner can match nothing, so we
+        # return immediately rather than silently dropping the filter (which
+        # would wrongly return every event).
+        if filter_process:
+            process_id_filter = log_data.get_id(IK_PROCESS_NAME, filter_process)
+            if process_id_filter is None:
+                await ctx.info(f"Filter: process '{filter_process}' not present in loaded data; no matches.")
+                return
+        else:
+            process_id_filter = None
+
+        if filter_operation:
+            operation_id_filter = log_data.get_id(IK_OPERATION, filter_operation)
+            if operation_id_filter is None:
+                await ctx.info(f"Filter: operation '{filter_operation}' not present in loaded data; no matches.")
+                return
+        else:
+            operation_id_filter = None
+
+        if filter_result:
+            result_id_filter = log_data.get_id(IK_RESULT, filter_result)
+            if result_id_filter is None:
+                await ctx.info(f"Filter: result '{filter_result}' not present in loaded data; no matches.")
+                return
+        else:
+            result_id_filter = None
 
         # Prepare case-insensitive substring filters
         filter_path_contains_lower = filter_path_contains.lower() if filter_path_contains else None

--- a/procmon_mcp/helpers.py
+++ b/procmon_mcp/helpers.py
@@ -93,6 +93,26 @@ def _parse_timestamp_str(ts_str: Optional[str]) -> Optional[float]:
         return None
 
 
+# --- Network Endpoint Parsing ---
+# Procmon renders network Path fields as "<local> -> <remote>", where an
+# endpoint is "host:port", "ipv4:port", or "[ipv6]:port". The host class covers
+# IPv4/IPv6 literals as well as DNS hostnames (letters, digits, dot, hyphen).
+_ENDPOINT_REGEX = re.compile(r".* -> \[?([A-Za-z0-9._:\-]+)\]?:(\d+)")
+
+
+def parse_network_endpoint(path_str: Optional[str]) -> Optional[str]:
+    """Extracts the remote 'host:port' endpoint from a Procmon network Path field.
+
+    Returns None if the path does not contain a recognisable remote endpoint.
+    """
+    if not path_str:
+        return None
+    match = _ENDPOINT_REGEX.match(path_str)
+    if not match:
+        return None
+    return f"{match.group(1)}:{match.group(2)}"
+
+
 # --- Byte Formatting ---
 def _format_bytes(bytes_val: int) -> str:
     """Formats bytes into a human-readable string (KB, MB, GB)."""

--- a/procmon_mcp/parser.py
+++ b/procmon_mcp/parser.py
@@ -8,7 +8,7 @@ import lzma
 import logging
 import contextlib
 from datetime import datetime, timezone, timedelta, time as dt_time
-from typing import Dict, Any, Optional, List, Iterator, IO
+from typing import Dict, Any, Optional, Iterator, IO
 
 from .compat import ET_impl, LXML_AVAILABLE
 from .constants import (
@@ -18,7 +18,7 @@ from .constants import (
     IK_PROCESS_NAME, IK_OPERATION, IK_PATH, IK_RESULT, IK_CATEGORY,
     IK_STACK_PATH, IK_STACK_LOCATION,
 )
-from .helpers import find_text_func, _strip_namespace, _clear_elem, _format_bytes
+from .helpers import find_text_func, _strip_namespace, _find_child_ignore_ns, _clear_elem, _format_bytes
 from .models import StringInterner, StackFrame, ProcessInfo, ProcmonLogData
 
 logger = logging.getLogger(__name__)
@@ -122,7 +122,10 @@ def _parse_xml_stream_for_loading(
     """
     parsing_stage = "seeking_eventlist"
     try:
-        tags_of_interest = ('event', 'frame', 'stack', 'eventlist', 'procmon')
+        # Only <event> (processed at end), plus the section/root markers used by
+        # the state machine. Stack <frame> elements are read from each event's
+        # fully-parsed subtree, so they don't need to trigger iterparse events.
+        tags_of_interest = ('event', 'eventlist', 'procmon')
         if LXML_AVAILABLE:
             context = ET_impl.iterparse(source_stream, events=('start', 'end'), tag=tags_of_interest)
         else:
@@ -137,8 +140,6 @@ def _parse_xml_stream_for_loading(
     skipped_count = 0
     start_time = time.time()
     last_report_time = start_time
-    current_event_data: Optional[Dict[str, Any]] = None
-    current_stack_frames: Optional[List[list]] = None
 
     # State for timestamp midnight rollover
     current_processing_date = BASE_DATE.date()
@@ -160,21 +161,19 @@ def _parse_xml_stream_for_loading(
                 continue
 
             elif parsing_stage == "parsing_events":
-                # --- Process <event> start ---
-                if event_type == 'start' and tag == 'event':
+                # Process each <event> only on its 'end' event. iterparse does
+                # NOT guarantee that an element's children/text are populated on
+                # the 'start' event (they are only complete by 'end'), so reading
+                # child fields early silently drops or corrupts events whenever a
+                # read-buffer boundary falls inside an <event>.
+                if event_type == 'end' and tag == 'event':
                     event_count += 1
-                    current_event_data = {}
-                    current_stack_frames = [] if load_stack else None
-
                     try:
                         pid_str = find_text_func(elem, 'PID')
                         ts_str = find_text_func(elem, 'Time_of_Day')
-                        current_event_data['pid_str'] = pid_str
-                        current_event_data['ts_str'] = ts_str
-                        current_event_data['pid'] = ProcessInfo._safe_text_to_int(pid_str)
+                        pid = ProcessInfo._safe_text_to_int(pid_str)
 
                         # Inline timestamp parsing with midnight rollover handling
-                        parsed_time_obj: Optional[dt_time] = None
                         ts_float: Optional[float] = None
                         if ts_str:
                             try:
@@ -209,28 +208,77 @@ def _parse_xml_stream_for_loading(
                             except (ValueError, TypeError, IndexError) as e:
                                 logger.warning(f"Could not parse timestamp string '{ts_str}': {e}")
 
-                        current_event_data['ts'] = ts_float
+                        # Validate required fields before building the event
+                        if pid is None or ts_float is None:
+                            skipped_count += 1
+                            if logger.isEnabledFor(logging.DEBUG):
+                                skip_reason = ""
+                                if pid is None:
+                                    skip_reason += f"Missing/invalid PID ('{pid_str}'). "
+                                if ts_float is None:
+                                    skip_reason += f"Missing/invalid Time_of_Day ('{ts_str}'). "
+                                logger.warning(f"Skipping event #{event_count}: {skip_reason.strip()}")
+                                try:
+                                    event_xml_str = ET_impl.tostring(elem, encoding='unicode', method='xml')
+                                    logger.debug(f"  Skipped Event XML:\n{event_xml_str[:1500]}...")
+                                except Exception as log_e:
+                                    logger.debug(f"  Could not serialize skipped event #{event_count} to string: {log_e}")
+                            _clear_elem(elem)
+                            continue
 
-                        # Extract other simple fields
-                        current_event_data['seq'] = ProcessInfo._safe_text_to_int(find_text_func(elem, 'SequenceNumber'))
-                        current_event_data['tid'] = ProcessInfo._safe_text_to_int(find_text_func(elem, 'ThreadId'))
-                        current_event_data['ppid'] = ProcessInfo._safe_text_to_int(find_text_func(elem, 'ParentPID'))
-                        current_event_data['detail'] = find_text_func(elem, 'Detail')
+                        opt_event: Dict[str, Any] = {
+                            'pid': pid,
+                            'ts': ts_float,
+                            'seq': ProcessInfo._safe_text_to_int(find_text_func(elem, 'SequenceNumber')),
+                            'tid': ProcessInfo._safe_text_to_int(find_text_func(elem, 'ThreadId')),
+                            'ppid': ProcessInfo._safe_text_to_int(find_text_func(elem, 'ParentPID')),
+                            'detail': find_text_func(elem, 'Detail'),
+                            'dur': None,
+                        }
                         duration_text = find_text_func(elem, 'Duration')
-                        current_event_data['dur'] = None
                         if duration_text:
                             try:
-                                current_event_data['dur'] = float(duration_text)
+                                opt_event['dur'] = float(duration_text)
                             except (ValueError, TypeError):
                                 pass
 
-                        # Extract fields for interning
-                        current_event_data['process_name_str'] = find_text_func(elem, 'Process_Name')
-                        current_event_data['operation_str'] = find_text_func(elem, 'Operation')
-                        current_event_data['path_str'] = find_text_func(elem, 'Path')
-                        current_event_data['result_str'] = find_text_func(elem, 'Result')
-                        current_event_data['category_str'] = find_text_func(elem, 'Category')
-                        current_event_data['process_index_str'] = find_text_func(elem, 'ProcessIndex')
+                        # Process name fallback logic
+                        process_name_str = find_text_func(elem, 'Process_Name')
+                        if process_name_str is None:
+                            process_index = ProcessInfo._safe_text_to_int(find_text_func(elem, 'ProcessIndex'))
+                            if process_index is not None:
+                                proc_info = processes.get(process_index)
+                                if proc_info:
+                                    process_name_str = proc_info.process_name
+                                    if opt_event.get('ppid') is None:
+                                        opt_event['ppid'] = proc_info.parent_pid
+                                else:
+                                    logger.warning(f"Event #{event_count} has ProcessIndex {process_index} but process info not found.")
+
+                        # String interning
+                        opt_event['pname_id'] = interners[IK_PROCESS_NAME].get_id(process_name_str)
+                        opt_event['op_id'] = interners[IK_OPERATION].get_id(find_text_func(elem, 'Operation'))
+                        opt_event['path_id'] = interners[IK_PATH].get_id(find_text_func(elem, 'Path'))
+                        opt_event['res_id'] = interners[IK_RESULT].get_id(find_text_func(elem, 'Result'))
+                        opt_event['cat_id'] = interners[IK_CATEGORY].get_id(find_text_func(elem, 'Category'))
+
+                        # Stack frames (read from the fully-parsed <stack> child)
+                        if load_stack:
+                            stack_elem = _find_child_ignore_ns(elem, 'stack')
+                            if stack_elem is not None:
+                                stack_frames = []
+                                for child in stack_elem:
+                                    if _strip_namespace(child.tag) != 'frame':
+                                        continue
+                                    try:
+                                        frame_obj = StackFrame.from_xml_element(child)
+                                        stack_frames.append(frame_obj.to_optimized_list(
+                                            interners[IK_STACK_PATH], interners[IK_STACK_LOCATION]
+                                        ))
+                                    except Exception as frame_e:
+                                        logger.warning(f"Failed to parse/optimize stack frame for event #{event_count}: {frame_e}", exc_info=False)
+                                if stack_frames:
+                                    opt_event['stack'] = stack_frames
 
                         # Handle extra data (if enabled)
                         if load_extra:
@@ -248,105 +296,32 @@ def _parse_xml_stream_for_loading(
                                     if tag_text is not None:
                                         extra_data_dict[child_tag_orig] = tag_text
                             if extra_data_dict:
-                                current_event_data['extra_data'] = extra_data_dict
+                                opt_event['extra_data'] = extra_data_dict
 
-                    except Exception as start_parse_err:
-                        logger.warning(f"Error during START event parsing for event #{event_count}: {start_parse_err}", exc_info=True)
-                        current_event_data = None
+                        yield opt_event
+                        yielded_count += 1
 
-                # --- Process <frame> start (only if loading stacks) ---
-                elif event_type == 'start' and tag == 'frame' and load_stack and current_stack_frames is not None:
-                    try:
-                        frame_obj = StackFrame.from_xml_element(elem)
-                        current_stack_frames.append(frame_obj.to_optimized_list(
-                            interners[IK_STACK_PATH], interners[IK_STACK_LOCATION]
-                        ))
-                    except Exception as frame_e:
-                        logger.warning(f"Failed to parse/optimize stack frame during START for event #{event_count}: {frame_e}", exc_info=False)
-
-                # --- Process <event> end ---
-                elif event_type == 'end' and tag == 'event':
-                    if current_event_data:
-                        parse_successful = True
-                        skip_reason = ""
-                        opt_event = {}
-
-                        if current_event_data.get('pid') is None:
-                            skip_reason += f"Missing/invalid PID ('{current_event_data.get('pid_str')}'). "
-                            parse_successful = False
-                        if current_event_data.get('ts') is None:
-                            skip_reason += f"Missing/invalid Time_of_Day ('{current_event_data.get('ts_str')}'). "
-                            parse_successful = False
-
-                        if parse_successful:
-                            opt_event['pid'] = current_event_data['pid']
-                            opt_event['ts'] = current_event_data['ts']
-                            opt_event['seq'] = current_event_data['seq']
-                            opt_event['tid'] = current_event_data['tid']
-                            opt_event['ppid'] = current_event_data['ppid']
-                            opt_event['detail'] = current_event_data['detail']
-                            opt_event['dur'] = current_event_data['dur']
-
-                            # Process name fallback logic
-                            process_name_str = current_event_data['process_name_str']
-                            if process_name_str is None:
-                                process_index = ProcessInfo._safe_text_to_int(current_event_data['process_index_str'])
-                                if process_index is not None:
-                                    proc_info = processes.get(process_index)
-                                    if proc_info:
-                                        process_name_str = proc_info.process_name
-                                        if opt_event.get('ppid') is None:
-                                            opt_event['ppid'] = proc_info.parent_pid
-                                    else:
-                                        logger.warning(f"Event #{event_count} has ProcessIndex {process_index} but process info not found.")
-
-                            # String interning
-                            opt_event['pname_id'] = interners[IK_PROCESS_NAME].get_id(process_name_str)
-                            opt_event['op_id'] = interners[IK_OPERATION].get_id(current_event_data['operation_str'])
-                            opt_event['path_id'] = interners[IK_PATH].get_id(current_event_data['path_str'])
-                            opt_event['res_id'] = interners[IK_RESULT].get_id(current_event_data['result_str'])
-                            opt_event['cat_id'] = interners[IK_CATEGORY].get_id(current_event_data['category_str'])
-
-                            if load_stack and current_stack_frames:
-                                opt_event['stack'] = current_stack_frames
-
-                            if 'extra_data' in current_event_data:
-                                opt_event['extra_data'] = current_event_data['extra_data']
-
-                            yield opt_event
-                            yielded_count += 1
-
-                            # Progress reporting
-                            current_time = time.time()
-                            if yielded_count % PROGRESS_REPORT_INTERVAL == 0 or (current_time - last_report_time) > PROGRESS_REPORT_SECONDS:
-                                elapsed_total = current_time - start_time
-                                rate = yielded_count / elapsed_total if elapsed_total > 0 else 0
-                                percent_str = ""
-                                if raw_file_stream and total_size is not None and total_size > 0:
-                                    try:
-                                        current_pos = raw_file_stream.tell()
-                                        percent = (current_pos / total_size) * 100
-                                        percent_str = f" ({percent:.1f}%)"
-                                    except (OSError, AttributeError, TypeError, io.UnsupportedOperation) as tell_err:
-                                        logger.debug(f"Could not get raw stream position for progress: {tell_err}")
-                                logger.info(f"  [Pass 2] Yielded {yielded_count:,} events{percent_str}... ({elapsed_total:.1f}s | {rate:,.0f} events/sec)")
-                                last_report_time = current_time
-                        else:
-                            skipped_count += 1
-                            if logger.isEnabledFor(logging.DEBUG):
-                                logger.warning(f"Skipping event #{event_count}: {skip_reason.strip()}")
+                        # Progress reporting
+                        current_time = time.time()
+                        if yielded_count % PROGRESS_REPORT_INTERVAL == 0 or (current_time - last_report_time) > PROGRESS_REPORT_SECONDS:
+                            elapsed_total = current_time - start_time
+                            rate = yielded_count / elapsed_total if elapsed_total > 0 else 0
+                            percent_str = ""
+                            if raw_file_stream and total_size is not None and total_size > 0:
                                 try:
-                                    event_xml_str = ET_impl.tostring(elem, encoding='unicode', method='xml')
-                                    logger.debug(f"  Skipped Event XML:\n{event_xml_str[:1500]}...")
-                                except Exception as log_e:
-                                    logger.debug(f"  Could not serialize skipped event #{event_count} to string: {log_e}")
+                                    current_pos = raw_file_stream.tell()
+                                    percent = (current_pos / total_size) * 100
+                                    percent_str = f" ({percent:.1f}%)"
+                                except (OSError, AttributeError, TypeError, io.UnsupportedOperation) as tell_err:
+                                    logger.debug(f"Could not get raw stream position for progress: {tell_err}")
+                            logger.info(f"  [Pass 2] Yielded {yielded_count:,} events{percent_str}... ({elapsed_total:.1f}s | {rate:,.0f} events/sec)")
+                            last_report_time = current_time
 
-                    current_event_data = None
-                    current_stack_frames = None
-                    _clear_elem(elem)
+                    except Exception as event_parse_err:
+                        logger.warning(f"Error parsing event #{event_count}: {event_parse_err}", exc_info=True)
+                    finally:
+                        _clear_elem(elem)
 
-                elif event_type == 'end' and tag == 'stack':
-                    _clear_elem(elem)
                 elif event_type == 'end' and tag == 'eventlist':
                     logger.debug("Reached end of <eventlist>.")
                     _clear_elem(elem)

--- a/procmon_mcp/tools.py
+++ b/procmon_mcp/tools.py
@@ -21,7 +21,7 @@ from . import server
 from .server import tool_decorator, _check_loaded
 from .filters import _iter_filtered_event_indices
 from .formatters import _get_formatted_event_details
-from .helpers import _format_bytes
+from .helpers import _format_bytes, parse_network_endpoint
 
 logger = logging.getLogger(__name__)
 
@@ -303,12 +303,12 @@ async def query_events(
         return filtered_event_summaries
 
     except (ValueError, TypeError, RuntimeError, re.error) as e:
+        # These are already meaningful client-facing errors (bad filter input,
+        # invalid regex, or an internal error surfaced by the filter iterator);
+        # re-raise as-is rather than double-wrapping.
         await ctx.error(f"[query_events] Failed: {e}")
         logger.debug("Query exception details:", exc_info=True)
-        if isinstance(e, (ValueError, TypeError, re.error)):
-            raise e
-        else:
-            raise RuntimeError(f"Internal error querying events: {e}") from e
+        raise
 
 
 @tool_decorator
@@ -789,7 +789,6 @@ async def find_network_connections(process_name: str, *, ctx: Context) -> List[s
         return []
 
     await ctx.info(f"[find_network_connections] Scanning {len(indices_to_check):,} events for '{process_name}'...")
-    endpoint_regex = re.compile(r".* -> \[?([a-fA-F0-9:.\-]+)\]?:(\d+)")
     processed_count = 0
     start_time = time.time()
     last_progress_report_time = start_time
@@ -801,10 +800,9 @@ async def find_network_connections(process_name: str, *, ctx: Context) -> List[s
 
         if op_id in network_op_ids:
             path_str = log_data.get_string(IK_PATH, event_dict.get('path_id'))
-            if path_str:
-                match = endpoint_regex.match(path_str)
-                if match:
-                    remote_endpoints.add(f"{match.group(1)}:{match.group(2)}")
+            endpoint = parse_network_endpoint(path_str)
+            if endpoint:
+                remote_endpoints.add(endpoint)
 
         current_time = time.time()
         if processed_count % 50000 == 0 or (current_time - last_progress_report_time > PROGRESS_REPORT_SECONDS):
@@ -850,6 +848,9 @@ async def export_query_results(
     if not output_file:
         raise ValueError("Output file name cannot be empty.")
 
+    # Ensure data is loaded before validating paths or creating directories.
+    log_data = await _check_loaded(ctx, "export_query_results")
+
     # Path validation (hardened)
     try:
         allowed_dir = os.path.abspath(os.getcwd())
@@ -873,7 +874,6 @@ async def export_query_results(
         await ctx.error(f"Invalid output file path: {e}")
         raise e
 
-    log_data = await _check_loaded(ctx, "export_query_results")
     if not log_data.events:
         await ctx.info("[export_query_results] Completed. No events loaded to export.")
         return {"success": True, "output_path": abs_output_path, "events_exported": 0}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,49 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "procmon-mcp"
+version = "0.1.0"
+description = "Model Context Protocol (MCP) server for analysing Process Monitor (Procmon) XML log files."
+readme = "README.md"
+requires-python = ">=3.7"
+license = { file = "LICENSE" }
+authors = [{ name = "JameZUK" }]
+keywords = ["mcp", "procmon", "process-monitor", "xml", "malware-analysis", "dfir"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Information Technology",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Topic :: Security",
+    "Topic :: System :: Monitoring",
+]
+dependencies = [
+    "mcp[cli]>=1.8.0",
+]
+
+[project.optional-dependencies]
+# Faster XML parsing (falls back to the stdlib ElementTree if absent).
+lxml = ["lxml>=4.9.0"]
+# Memory-usage reporting after loading (silently skipped if absent).
+psutil = ["psutil>=5.9.0"]
+# Everything optional, for convenience.
+all = ["lxml>=4.9.0", "psutil>=5.9.0"]
+# Development/test tooling.
+dev = ["pytest>=7.0", "lxml>=4.9.0", "psutil>=5.9.0"]
+
+[project.urls]
+Homepage = "https://github.com/JameZUK/ProcmonMCP"
+Repository = "https://github.com/JameZUK/ProcmonMCP"
+Issues = "https://github.com/JameZUK/ProcmonMCP/issues"
+
+[project.scripts]
+procmon-mcp = "procmon_mcp.cli:main"
+
+[tool.setuptools]
+packages = ["procmon_mcp"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,8 @@
+# Required
 mcp[cli]>=1.8.0
-lxml>=4.9.0
-psutil>=5.9.0
+
+# Optional (the server runs without these, with graceful fallbacks):
+#   lxml   - faster XML parsing; falls back to the stdlib ElementTree if absent
+#   psutil - memory-usage reporting after loading; silently skipped if absent
+# Install the optional extras with:  pip install lxml psutil
+# (or, from a checkout:  pip install -e ".[all]")

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -489,3 +489,123 @@ class TestConfig:
         config = load_config()
         assert config["last_file"] == "/tmp/x.xml"
         assert "unknown_key" not in config
+
+
+# --- Network Endpoint Parsing Tests ---
+
+class TestParseNetworkEndpoint:
+    def test_ipv4(self):
+        assert procmon_mcp.parse_network_endpoint(
+            "test.exe:1234 -> 93.184.216.34:443") == "93.184.216.34:443"
+
+    def test_ipv6_bracketed(self):
+        assert procmon_mcp.parse_network_endpoint(
+            "test.exe -> [fe80::1]:443") == "fe80::1:443"
+
+    def test_hostname(self):
+        assert procmon_mcp.parse_network_endpoint(
+            "host:5000 -> example-host.local:8080") == "example-host.local:8080"
+
+    def test_no_arrow_returns_none(self):
+        assert procmon_mcp.parse_network_endpoint("C:\\Windows\\file.dll") is None
+
+    def test_none_returns_none(self):
+        assert procmon_mcp.parse_network_endpoint(None) is None
+
+    def test_empty_returns_none(self):
+        assert procmon_mcp.parse_network_endpoint("") is None
+
+    def test_missing_port_returns_none(self):
+        assert procmon_mcp.parse_network_endpoint("a -> 10.0.0.1") is None
+
+
+# --- Parser Integration Tests ---
+
+def _write_capture(path, n_events, with_stack=True):
+    """Write a synthetic Procmon XML capture with n_events events.
+
+    The file is intentionally large enough that <event> elements span
+    iterparse read-buffer boundaries, which is the condition that previously
+    caused events to be silently dropped or have null fields.
+    """
+    parts = [
+        '<?xml version="1.0" encoding="UTF-8"?>\n<procmon>\n<processlist>\n',
+        '<process><ProcessIndex>0</ProcessIndex><ProcessId>1234</ProcessId>'
+        '<ParentProcessId>4</ParentProcessId><ProcessName>test.exe</ProcessName>'
+        '<ImagePath>C:\\test.exe</ImagePath></process>\n',
+        '</processlist>\n<eventlist>\n',
+    ]
+    for i in range(n_events):
+        stack = ''
+        if with_stack:
+            stack = ('<stack><frame><depth>0</depth><address>0x%x</address>'
+                     '<path>ntdll.dll</path><location>Nt+0x%x</location></frame></stack>' % (i, i))
+        parts.append(
+            '<event><ProcessIndex>0</ProcessIndex>'
+            '<Time_of_Day>12:00:%02d.000000</Time_of_Day>'
+            '<PID>1234</PID><Operation>CreateFile</Operation>'
+            '<Path>C:\\Windows\\System32\\file_%d.dll</Path><Result>SUCCESS</Result>'
+            '<Process_Name>test.exe</Process_Name>%s</event>\n' % (i % 60, i, stack)
+        )
+    parts.append('</eventlist>\n</procmon>\n')
+    with open(path, 'w', encoding='utf-8') as f:
+        f.write(''.join(parts))
+
+
+class TestParserIntegration:
+    def test_small_capture_parses_all_fields(self, tmp_path):
+        from procmon_mcp.parser import load_procmon_xml
+        from procmon_mcp.constants import IK_OPERATION, IK_PATH, IK_RESULT, IK_PROCESS_NAME
+        path = str(tmp_path / "small.xml")
+        _write_capture(path, 3)
+        data = load_procmon_xml(path, load_stack=True, load_extra=True)
+        assert len(data.events) == 3
+        assert len(data.processes_by_index) == 1
+        e = data.events[0]
+        assert e['pid'] == 1234
+        assert data.get_string(IK_OPERATION, e['op_id']) == "CreateFile"
+        assert data.get_string(IK_RESULT, e['res_id']) == "SUCCESS"
+        assert data.get_string(IK_PROCESS_NAME, e['pname_id']) == "test.exe"
+        assert "System32" in data.get_string(IK_PATH, e['path_id'])
+
+    def test_large_capture_drops_no_events(self, tmp_path):
+        """Regression: events spanning read-buffer boundaries must not be lost.
+
+        Previously, reading child fields on the iterparse 'start' event silently
+        dropped events (and nulled later fields like Path/Result) whenever a
+        buffer boundary fell inside an <event>.
+        """
+        from procmon_mcp.parser import load_procmon_xml
+        n = 20000
+        path = str(tmp_path / "large.xml")
+        _write_capture(path, n, with_stack=True)
+        data = load_procmon_xml(path, load_stack=True, load_extra=True)
+        assert len(data.events) == n
+        # No event may have a missing core field.
+        for e in data.events:
+            assert e.get('pid') is not None
+            assert e.get('op_id') is not None
+            assert e.get('path_id') is not None
+            assert e.get('res_id') is not None
+            assert e.get('pname_id') is not None
+        # Every event carried a stack frame; all must be present.
+        assert sum(1 for e in data.events if 'stack' in e) == n
+
+    def test_large_capture_no_stack_flag(self, tmp_path):
+        from procmon_mcp.parser import load_procmon_xml
+        n = 20000
+        path = str(tmp_path / "large_nostack.xml")
+        _write_capture(path, n, with_stack=True)
+        data = load_procmon_xml(path, load_stack=False, load_extra=False)
+        assert len(data.events) == n
+        assert all('stack' not in e for e in data.events)
+
+    def test_indices_cover_all_events(self, tmp_path):
+        from procmon_mcp.parser import load_procmon_xml
+        n = 5000
+        path = str(tmp_path / "idx.xml")
+        _write_capture(path, n, with_stack=False)
+        data = load_procmon_xml(path, load_stack=False, load_extra=False)
+        # Every event index should appear exactly once in the PID index.
+        assert sum(len(v) for v in data.pid_index.values()) == n
+        assert sum(len(v) for v in data.pname_id_index.values()) == n

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -2,6 +2,7 @@
 import sys
 import os
 import re
+import asyncio
 import pytest
 from datetime import datetime, timezone
 from xml.etree import ElementTree as ET
@@ -609,3 +610,62 @@ class TestParserIntegration:
         # Every event index should appear exactly once in the PID index.
         assert sum(len(v) for v in data.pid_index.values()) == n
         assert sum(len(v) for v in data.pname_id_index.values()) == n
+
+
+# --- Exact-Match Filter Tests ---
+
+def _collect_filtered(log_data, **filters):
+    """Drain the async filter iterator into a list of event indices."""
+    from procmon_mcp.compat import Context
+
+    async def _run():
+        ctx = Context()
+        out = []
+        async for idx in procmon_mcp._iter_filtered_event_indices(
+                log_data=log_data, ctx=ctx, **filters):
+            out.append(idx)
+        return out
+
+    return asyncio.run(_run())
+
+
+class TestFilterExactMatch:
+    """Synthetic capture: N identical CreateFile / SUCCESS / test.exe events."""
+
+    def _load(self, tmp_path, n=10):
+        from procmon_mcp.parser import load_procmon_xml
+        path = str(tmp_path / "filt.xml")
+        _write_capture(path, n, with_stack=False)
+        return load_procmon_xml(path, load_stack=False, load_extra=False)
+
+    def test_present_operation_matches_all(self, tmp_path):
+        data = self._load(tmp_path)
+        assert len(_collect_filtered(data, filter_operation="CreateFile")) == 10
+
+    def test_present_result_matches_all(self, tmp_path):
+        data = self._load(tmp_path)
+        assert len(_collect_filtered(data, filter_result="SUCCESS")) == 10
+
+    def test_present_process_matches_all(self, tmp_path):
+        data = self._load(tmp_path)
+        assert len(_collect_filtered(data, filter_process="test.exe")) == 10
+
+    def test_absent_operation_matches_none(self, tmp_path):
+        # Regression: an absent exact-match value must yield 0, not every event.
+        data = self._load(tmp_path)
+        assert _collect_filtered(data, filter_operation="RegSetValue") == []
+
+    def test_absent_result_matches_none(self, tmp_path):
+        data = self._load(tmp_path)
+        assert _collect_filtered(data, filter_result="ACCESS DENIED") == []
+
+    def test_absent_process_matches_none(self, tmp_path):
+        data = self._load(tmp_path)
+        assert _collect_filtered(data, filter_process="nonexistent.exe") == []
+
+    def test_absent_value_does_not_leak_with_other_filters(self, tmp_path):
+        # Combining a present operation with an absent result still yields 0.
+        data = self._load(tmp_path)
+        res = _collect_filtered(data, filter_operation="CreateFile",
+                                filter_result="ACCESS DENIED")
+        assert res == []


### PR DESCRIPTION
## Summary

Reviewed the project and fixed two correctness bugs (one critical) plus a set of packaging/cleanup items. All changes verified against three real Procmon captures (49k / 113k / 368k events; plain XML and `.xz`) and a regression-tested unit suite (**96 passing**, with and without `lxml`).

## Bug fixes

### 🔴 Critical — silent event loss/corruption on large files (`parser.py`)
`_parse_xml_stream_for_loading` extracted every event field on the iterparse **`start`** event of `<event>`. `iterparse` does not guarantee an element's children/text are populated at `start` (only by `end`), so any event straddling a read-buffer boundary was silently dropped or kept with null `Operation`/`Path`/`Result`. On a 20k-event capture this lost ~0.5% of events and corrupted dozens more, in both the lxml and stdlib backends.

**Fix:** all field extraction (including stack frames, read from the event's fully-parsed `<stack>` subtree) now happens on the `<event>` **end** event — matching how Pass 1 already parses `<process>`. Verified on real captures: 48,961 / 112,712 / 367,564 events all load with **0 skipped** and no null core fields.

### 🟡 Exact-match filters returned all events for absent values (`filters.py`)
When `filter_process`/`filter_operation`/`filter_result` was supplied but the value wasn't present in the data, `get_id()` returned `None` and the filter treated `None` as "not applied", returning **every** event instead of zero. Found while testing a real capture: `filter_result="ACCESS DENIED"` on a capture with no such result matched all 112,712 events (and corrupted `export_query_results`). Now a supplied-but-absent exact-match value short-circuits to zero matches.

## Cleanups
- `query_events`: drop redundant `isinstance` re-check that double-wrapped `RuntimeError`s.
- `export_query_results`: verify a file is loaded before validating paths / creating directories.
- `find_network_connections`: extract the endpoint regex into a tested helper and broaden the host class so DNS hostnames match (not just IP/hex hosts as the docstring promised).

## Packaging / docs
- Add MIT `LICENSE` + README License section.
- Add `pyproject.toml` (setuptools) with a `procmon-mcp` console script and `lxml`/`psutil`/`all`/`dev` extras.
- `requirements.txt` now lists only `mcp[cli]` as required; `lxml`/`psutil` documented as optional (matches the code's fallbacks).
- Add GitHub Actions CI (Python 3.10–3.13, with and without lxml).
- Regenerate the stale `REVIEW.md` for the modular package.
- `.gitignore` local `captures/` and `*.pml` so sensitive Procmon logs are never committed.

## Tests
- `TestParserIntegration` — loads a 20k-event capture; asserts zero drops, zero null core fields, complete stacks (both backends).
- `TestFilterExactMatch` — present and absent process/operation/result values, including combined filters.
- `TestParseNetworkEndpoint` — IPv4, bracketed IPv6, DNS hostname.

🤖 Generated with [Claude Code](https://claude.com/claude-code)