### PR TITLE
Fix FastMCP constructor: use instructions= instead of description=

### DIFF
--- a/procmon_mcp/compat.py
+++ b/procmon_mcp/compat.py
@@ -62,9 +62,9 @@ except ImportError:
         log_level = "INFO"
 
     class MockMCP:
-        def __init__(self, name, description=""):
+        def __init__(self, name, instructions=""):
             self.name = name
-            self.description = description
+            self.instructions = instructions
             self.app = object()
             self.settings = MockSettings()
             self._run_called_with_transport = None

--- a/procmon_mcp/server.py
+++ b/procmon_mcp/server.py
@@ -20,9 +20,9 @@ _SERVER_DESC = (
 )
 
 if MCP_SDK_AVAILABLE:
-    mcp = FastMCP("ProcmonMCP", description=_SERVER_DESC)
+    mcp = FastMCP("ProcmonMCP", instructions=_SERVER_DESC)
 else:
-    mcp = FastMCP("ProcmonMCP (Mock)", description=_SERVER_DESC)
+    mcp = FastMCP("ProcmonMCP (Mock)", instructions=_SERVER_DESC)
 
 
 async def _check_loaded(ctx: Context, tool_name: str) -> ProcmonLogData:


### PR DESCRIPTION
Importing `procmon_mcp.server` fails on the current MCP SDK with this error:

```
TypeError: FastMCP.__init__() got an unexpected keyword argument 'description'
```

The `FastMCP` constructor in `mcp.server.fastmcp` accepts an `instructions=` keyword. The server passes `description=` on two lines, so the module raises at import time. I reproduced this on `mcp` 1.28.0. The `requirements.txt` already allows `mcp[cli]>=1.8.0` with no upper bound, so a fresh install pulls a version that rejects `description=`.

The fix has two parts:

- **`procmon_mcp/server.py`** — Pass `instructions=_SERVER_DESC` to `FastMCP` in both the SDK and mock branches.
- **`procmon_mcp/compat.py`** — Update `MockMCP` to accept `instructions` and store it as `self.instructions`, matching the real constructor.

I tested in fresh virtualenvs, with the SDK installed and without it:

| Setup | Before | After |
|---|---|---|
| SDK present (`mcp` 1.28.0) | TypeError at import | Imports, builds FastMCP |
| No SDK (offline mock) | Imports, builds MockMCP | Imports, builds MockMCP |

Patching only `server.py` leaves `MockMCP` expecting `description`, so the offline path raises a `TypeError`. Updating `compat.py` keeps both paths consistent.
