### PR TITLE
Harden CI/tests against MCP SDK signature regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, master]
+    branches: [procmon_parser, main, master]
   pull_request:
 
 jobs:
@@ -35,3 +35,28 @@ jobs:
         run: |
           pip uninstall -y lxml
           pytest -q
+
+  sdk-smoke:
+    # Installs the real MCP SDK so the server's import path (FastMCP
+    # construction) is exercised end-to-end. The mock-based 'test' job cannot
+    # catch SDK-signature regressions such as the FastMCP instructions= fix.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install with the MCP SDK
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest lxml
+          pip install ".[all]"
+
+      - name: Import server (FastMCP construction smoke test)
+        run: python -c "import procmon_mcp.server as s; assert s.mcp is not None; print('server import OK')"
+
+      - name: Run tests with the SDK present
+        run: pytest -q

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -614,12 +614,32 @@ class TestParserIntegration:
 
 # --- Exact-Match Filter Tests ---
 
+class _DummyContext:
+    """Minimal MCP Context stand-in for driving tools/filters in tests.
+
+    Intentionally self-contained rather than imported from procmon_mcp.compat:
+    when the real MCP SDK is installed, compat.Context is the SDK Context, whose
+    info()/error() raise outside an active request. The tool code only needs
+    awaitable info/error/warning that record nothing.
+    """
+    def __init__(self):
+        self.messages = []
+
+    async def info(self, msg):
+        self.messages.append(("info", msg))
+
+    async def error(self, msg):
+        self.messages.append(("error", msg))
+
+    async def warning(self, msg):
+        self.messages.append(("warning", msg))
+
+
 def _collect_filtered(log_data, **filters):
     """Drain the async filter iterator into a list of event indices."""
-    from procmon_mcp.compat import Context
 
     async def _run():
-        ctx = Context()
+        ctx = _DummyContext()
         out = []
         async for idx in procmon_mcp._iter_filtered_event_indices(
                 log_data=log_data, ctx=ctx, **filters):


### PR DESCRIPTION
## Why

PR #5 fixed a crash where `procmon_mcp.server` failed to import because it passed `description=` to `FastMCP` (the SDK accepts `instructions=`). That bug reached the default branch because CI never installs the MCP SDK — `compat.py` substitutes a mock when the SDK is absent, so import-time / construction regressions are invisible to the existing `test` job.

This PR closes that gap.

## Changes

- **CI `sdk-smoke` job:** installs the real MCP SDK (`pip install ".[all]"` pulls in `mcp[cli]`), imports `procmon_mcp.server` as a smoke test (exercising real `FastMCP` construction), and runs the full suite with the SDK present.
- **CI push trigger:** add `procmon_parser` (the repo's default branch) to `on.push.branches` — it was `[main, master]`, so push CI wasn't running on the default branch.
- **Test robustness:** the exact-match filter tests imported `Context` from `procmon_mcp.compat`, which resolves to the *real* SDK `Context` when installed. A bare `Context()` raises `"not available outside of a request"` on `info()`/`error()`, failing 4 tests under the SDK. They now use a self-contained dummy context. (Production is unaffected — FastMCP always injects a live request context.)

## Verification

- Full suite passes **with** the SDK installed (96/96) and **without** it (mock path, 96/96).
- Smoke import builds a real `FastMCP` instance.
- `ci.yml` validated as well-formed YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)