### PR TITLE
Parse service-name ports in network endpoints

### DIFF
--- a/procmon_mcp/helpers.py
+++ b/procmon_mcp/helpers.py
@@ -97,7 +97,10 @@ def _parse_timestamp_str(ts_str: Optional[str]) -> Optional[float]:
 # Procmon renders network Path fields as "<local> -> <remote>", where an
 # endpoint is "host:port", "ipv4:port", or "[ipv6]:port". The host class covers
 # IPv4/IPv6 literals as well as DNS hostnames (letters, digits, dot, hyphen).
-_ENDPOINT_REGEX = re.compile(r".* -> \[?([A-Za-z0-9._:\-]+)\]?:(\d+)")
+# The port may be numeric (443) OR a resolved service name (domain, https),
+# which Procmon emits for well-known ports unless "Show resolved network
+# addresses" is disabled.
+_ENDPOINT_REGEX = re.compile(r".* -> \[?([A-Za-z0-9._:\-]+)\]?:([A-Za-z0-9\-]+)$")
 
 
 def parse_network_endpoint(path_str: Optional[str]) -> Optional[str]:

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -519,6 +519,23 @@ class TestParseNetworkEndpoint:
     def test_missing_port_returns_none(self):
         assert procmon_mcp.parse_network_endpoint("a -> 10.0.0.1") is None
 
+    def test_service_name_port_dns(self):
+        # Procmon resolves well-known ports to service names (e.g. 53 -> domain).
+        assert procmon_mcp.parse_network_endpoint(
+            "DESKTOP-VQV04L8.localdomain:59075 -> 192.168.249.2:domain") == "192.168.249.2:domain"
+
+    def test_service_name_port_https(self):
+        assert procmon_mcp.parse_network_endpoint(
+            "PC:1 -> server.corp:https") == "server.corp:https"
+
+    def test_service_name_port_hyphenated(self):
+        assert procmon_mcp.parse_network_endpoint(
+            "PC:1 -> 10.0.0.5:microsoft-ds") == "10.0.0.5:microsoft-ds"
+
+    def test_ipv6_with_service_name_port(self):
+        assert procmon_mcp.parse_network_endpoint(
+            "a:1 -> [2001:db8::1]:https") == "2001:db8::1:https"
+
 
 # --- Parser Integration Tests ---
 


### PR DESCRIPTION
## Why

Procmon resolves well-known ports to **service names** (`192.168.249.2:domain` for DNS, `:https` for 443, etc.) unless "Show resolved network addresses" is turned off. `parse_network_endpoint` required a numeric port (`:(\d+)`), so it silently failed to match those paths and returned `None`.

Effect: both `list_network_connections` (added in #7) and `find_network_connections` returned **empty results** on captures whose network traffic was DNS/HTTPS. Reproduced on a real capture — `svchost.exe` UDP/DNS events yielded nothing despite 12 visible connections:

```
DESKTOP-VQV04L8.localdomain:59075 -> 192.168.249.2:domain
```

## Fix

Broaden the port to accept service names (`[A-Za-z0-9\-]+`) and anchor the match to end-of-string. Numeric ports, bracketed IPv6, and DNS hostnames all still parse.

| Path | Before | After |
|------|--------|-------|
| `… -> 93.184.216.34:443` | `93.184.216.34:443` | `93.184.216.34:443` |
| `… -> [fe80::1]:443` | `fe80::1:443` | `fe80::1:443` |
| `… -> 192.168.249.2:domain` | **None** | `192.168.249.2:domain` |
| `… -> server.corp:https` | **None** | `server.corp:https` |
| `… -> 10.0.0.5:microsoft-ds` | **None** | `10.0.0.5:microsoft-ds` |

## Verification

- Added tests for DNS/HTTPS/hyphenated service-name ports and IPv6-with-service-name; full suite **100 passing** with and without lxml.
- End-to-end on a real capture: `list_network_connections` now returns the `svchost.exe → 192.168.249.2:domain` records (and `find_network_connections("svchost.exe")` likewise), where both previously returned `[]`.

Relates to #9 (enriching network analysis output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)