### PR TITLE
Enrich network analysis output (closes #9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,9 @@ No API keys or authentication tokens are required — ProcmonMCP is a purely loc
 | `get_timing_statistics(group_by)` | Calculates duration statistics grouped by process or operation. |
 | `get_process_lifetime(pid)` | Finds the Process Create and Process Exit timestamps for a given PID. |
 | `find_file_access(path_contains, limit?)` | Finds file system events matching a path substring (case-insensitive). |
-| `find_network_connections(process_name)` | Finds unique remote network endpoints accessed by a process. |
+| `find_network_connections(process_name)` | Returns enriched records for the remote endpoints a process accessed: endpoint, host/ip/hostname/port, operations, inferred directions (connect/send/receive), results, event count, and first/last-seen timestamps — ranked by count. |
+| `list_network_connections(limit?)` | Capture-wide network triage: one enriched record per (process, PID, endpoint) across all processes, ranked by event count. |
+| `get_network_top_talkers(limit?)` | Ranks unique remote endpoints across the whole capture by event count, with the count of distinct processes (and their names) that touched each. |
 
 ### Export Tools
 
@@ -328,7 +330,9 @@ Then in Cline, select MCP Servers and add:
 - "Get details for process PID 4568." *(Check command line, parent PID, image path)*
 - "Summarise operations for process `suspicious.exe`."
 - "Query events where filter_process is `suspicious.exe` and filter_operation is `RegSetValue`, limit 10."
-- "Find network connections for process `suspicious.exe`."
+- "Find network connections for process `suspicious.exe`." *(Enriched: directions, results, counts, first/last-seen)*
+- "List network connections across the whole capture." *(Capture-wide triage, busiest first)*
+- "Show the network top talkers." *(Rank remote endpoints by event count)*
 - "Find file access containing `temp\\suspicious_data`, limit 50."
 
 ### Looking for Persistence

--- a/procmon_mcp/__init__.py
+++ b/procmon_mcp/__init__.py
@@ -19,6 +19,7 @@ from .helpers import (
     _compile_safe_regex, _strip_namespace, _find_child_ignore_ns,
     _find_text_ignore_ns, find_text_func, _clear_elem,
     _parse_timestamp_str, _format_bytes, parse_network_endpoint,
+    parse_network_endpoint_parts, network_direction,
 )
 
 # Data models

--- a/procmon_mcp/helpers.py
+++ b/procmon_mcp/helpers.py
@@ -1,8 +1,9 @@
 """XML helper functions, regex utilities, timestamp parsing, and formatting."""
 import re
 import logging
+import ipaddress
 from datetime import datetime, timezone, time as dt_time
-from typing import Optional
+from typing import Optional, Dict, Any
 
 from .compat import ET_impl
 from .constants import PROCMON_TIMESTAMP_FORMAT, BASE_DATE, MAX_REGEX_LEN
@@ -103,17 +104,65 @@ def _parse_timestamp_str(ts_str: Optional[str]) -> Optional[float]:
 _ENDPOINT_REGEX = re.compile(r".* -> \[?([A-Za-z0-9._:\-]+)\]?:([A-Za-z0-9\-]+)$")
 
 
-def parse_network_endpoint(path_str: Optional[str]) -> Optional[str]:
-    """Extracts the remote 'host:port' endpoint from a Procmon network Path field.
+def _host_is_ip(host: str) -> bool:
+    """True if `host` is a literal IPv4/IPv6 address rather than a hostname."""
+    try:
+        ipaddress.ip_address(host)
+        return True
+    except ValueError:
+        return False
 
-    Returns None if the path does not contain a recognisable remote endpoint.
+
+def parse_network_endpoint_parts(path_str: Optional[str]) -> Optional[Dict[str, Any]]:
+    """Parses a Procmon network Path field into structured remote-endpoint parts.
+
+    Returns a dict with keys ``endpoint`` (``host:port``), ``host``, ``port``,
+    ``ip`` (set when the host is a literal IP, else None), and ``hostname`` (set
+    when the host is a DNS name, else None). Returns None when the path has no
+    recognisable remote endpoint.
     """
     if not path_str:
         return None
     match = _ENDPOINT_REGEX.match(path_str)
     if not match:
         return None
-    return f"{match.group(1)}:{match.group(2)}"
+    host, port = match.group(1), match.group(2)
+    is_ip = _host_is_ip(host)
+    return {
+        "endpoint": f"{host}:{port}",
+        "host": host,
+        "port": port,
+        "ip": host if is_ip else None,
+        "hostname": None if is_ip else host,
+    }
+
+
+def parse_network_endpoint(path_str: Optional[str]) -> Optional[str]:
+    """Extracts the remote 'host:port' endpoint from a Procmon network Path field.
+
+    Returns None if the path does not contain a recognisable remote endpoint.
+    """
+    parts = parse_network_endpoint_parts(path_str)
+    return parts["endpoint"] if parts else None
+
+
+# Procmon network operations encode a direction in their name.
+def network_direction(operation: Optional[str]) -> Optional[str]:
+    """Infers the connection direction ('connect'/'send'/'receive') from an op name."""
+    if not operation:
+        return None
+    op = operation.lower()
+    if "connect" in op:
+        return "connect"
+    if "send" in op:
+        return "send"
+    if "receive" in op:
+        return "receive"
+    if "accept" in op:
+        return "accept"
+    if "disconnect" in op:
+        return "disconnect"
+    return None
 
 
 # --- Byte Formatting ---

--- a/procmon_mcp/tools.py
+++ b/procmon_mcp/tools.py
@@ -21,7 +21,7 @@ from . import server
 from .server import tool_decorator, _check_loaded
 from .filters import _iter_filtered_event_indices
 from .formatters import _get_formatted_event_details
-from .helpers import _format_bytes, parse_network_endpoint
+from .helpers import _format_bytes, parse_network_endpoint_parts, network_direction
 
 logger = logging.getLogger(__name__)
 
@@ -759,22 +759,121 @@ async def find_file_access(path_contains: str, limit: int = 100, *, ctx: Context
     return found_events
 
 
-@tool_decorator
-async def find_network_connections(process_name: str, *, ctx: Context) -> List[str]:
+def _format_ts(ts: Optional[float]) -> Optional[str]:
+    """Formats a Unix timestamp as a Procmon time-of-day string, or None."""
+    if ts is None:
+        return None
+    try:
+        return datetime.fromtimestamp(ts, timezone.utc).strftime(PROCMON_TIMESTAMP_FORMAT)
+    except (ValueError, OverflowError, OSError):
+        return None
+
+
+def _network_op_ids(log_data) -> set:
+    """Returns the set of interned operation IDs for known network operations."""
+    return {
+        oid for oid in (log_data.get_id(IK_OPERATION, op) for op in NETWORK_OPERATIONS)
+        if oid is not None
+    }
+
+
+def _aggregate_network(log_data, indices, network_op_ids: set, group_by_process: bool) -> List[Dict[str, Any]]:
+    """Aggregates network events (by index) into enriched remote-endpoint records.
+
+    Each record carries the endpoint (host:port), split host/ip/hostname/port,
+    the operations and inferred directions seen, the distinct results, an event
+    count, and first/last-seen timestamps. When ``group_by_process`` is True the
+    grouping key is (process_name, pid, endpoint); otherwise it is the endpoint
+    alone (capture-wide rollup), with a process list/count attached.
     """
-    Finds unique remote network endpoints (IP:port or Hostname:port) accessed by a specific process.
+    agg: Dict[Any, Dict[str, Any]] = {}
+    for idx in indices:
+        event_dict = log_data.events[idx]
+        if event_dict.get('op_id') not in network_op_ids:
+            continue
+        parts = parse_network_endpoint_parts(log_data.get_string(IK_PATH, event_dict.get('path_id')))
+        if not parts:
+            continue
+        pname = log_data.get_string(IK_PROCESS_NAME, event_dict.get('pname_id'))
+        pid = event_dict.get('pid')
+        operation = log_data.get_string(IK_OPERATION, event_dict.get('op_id'))
+        result = log_data.get_string(IK_RESULT, event_dict.get('res_id'))
+        ts = event_dict.get('ts')
+        endpoint = parts['endpoint']
+        key = (pname, pid, endpoint) if group_by_process else endpoint
+
+        rec = agg.get(key)
+        if rec is None:
+            rec = {
+                'endpoint': endpoint, 'host': parts['host'], 'port': parts['port'],
+                'ip': parts['ip'], 'hostname': parts['hostname'], 'count': 0,
+                '_ops': set(), '_dirs': set(), '_results': set(),
+                '_first': ts, '_last': ts, '_procs': set(),
+            }
+            if group_by_process:
+                rec['process_name'] = pname
+                rec['pid'] = pid
+            agg[key] = rec
+
+        rec['count'] += 1
+        if operation:
+            rec['_ops'].add(operation)
+        direction = network_direction(operation)
+        if direction:
+            rec['_dirs'].add(direction)
+        if result:
+            rec['_results'].add(result)
+        if pname is not None or pid is not None:
+            rec['_procs'].add((pname, pid))
+        if ts is not None:
+            if rec['_first'] is None or ts < rec['_first']:
+                rec['_first'] = ts
+            if rec['_last'] is None or ts > rec['_last']:
+                rec['_last'] = ts
+
+    records: List[Dict[str, Any]] = []
+    for rec in agg.values():
+        first = rec.pop('_first')
+        last = rec.pop('_last')
+        rec['operations'] = sorted(rec.pop('_ops'))
+        rec['directions'] = sorted(rec.pop('_dirs'))
+        rec['results'] = sorted(rec.pop('_results'))
+        procs = rec.pop('_procs')
+        rec['first_seen_unix'] = first
+        rec['last_seen_unix'] = last
+        rec['first_seen'] = _format_ts(first)
+        rec['last_seen'] = _format_ts(last)
+        if not group_by_process:
+            rec['process_count'] = len(procs)
+            rec['processes'] = sorted(
+                f"{name} (PID {p})" if p is not None else str(name)
+                for name, p in procs if name is not None or p is not None
+            )
+        records.append(rec)
+    return records
+
+
+@tool_decorator
+async def find_network_connections(process_name: str, *, ctx: Context) -> List[Dict[str, Any]]:
+    """
+    Finds remote network endpoints accessed by a specific process, with enrichment.
     Uses a case-sensitive, exact match for the process name.
-    Scans events matching the process name for network operations (TCP/UDP Send/Receive/Connect) and extracts endpoints from the 'Path' field.
-    Returns a sorted list of unique endpoint strings.
+
+    Scans the process's network operations (TCP/UDP Connect/Send/Receive) and returns
+    one record per unique (PID, endpoint), each containing: endpoint (host:port), host,
+    ip, hostname, port, the operations and inferred directions (connect/send/receive)
+    seen, distinct results, an event count, and first/last-seen timestamps.
+    Records are sorted by event count (descending). Returns an empty list if the process
+    has no recognised network endpoints.
     """
     log_data = await _check_loaded(ctx, "find_network_connections")
     await ctx.info(f"[find_network_connections] Starting for process: '{process_name}'")
     if not process_name:
         await ctx.error("[find_network_connections] process_name filter cannot be empty.")
         raise ValueError("process_name filter is required.")
-    remote_endpoints = set()
+
     target_pname_id = log_data.get_id(IK_PROCESS_NAME, process_name)
-    network_op_ids = {log_data.get_id(IK_OPERATION, op) for op in NETWORK_OPERATIONS if log_data.get_id(IK_OPERATION, op) is not None}
+    network_op_ids = _network_op_ids(log_data)
 
     if target_pname_id is None:
         await ctx.warning(f"[find_network_connections] Process name '{process_name}' not found in loaded data.")
@@ -789,33 +888,10 @@ async def find_network_connections(process_name: str, *, ctx: Context) -> List[s
         return []
 
     await ctx.info(f"[find_network_connections] Scanning {len(indices_to_check):,} events for '{process_name}'...")
-    processed_count = 0
-    start_time = time.time()
-    last_progress_report_time = start_time
-
-    for idx in indices_to_check:
-        processed_count += 1
-        event_dict = log_data.events[idx]
-        op_id = event_dict.get('op_id')
-
-        if op_id in network_op_ids:
-            path_str = log_data.get_string(IK_PATH, event_dict.get('path_id'))
-            endpoint = parse_network_endpoint(path_str)
-            if endpoint:
-                remote_endpoints.add(endpoint)
-
-        current_time = time.time()
-        if processed_count % 50000 == 0 or (current_time - last_progress_report_time > PROGRESS_REPORT_SECONDS):
-            elapsed = current_time - start_time
-            try:
-                await ctx.info(f"[find_network_connections] Scanned {processed_count:,}/{len(indices_to_check):,} events ({elapsed:.1f}s)")
-            except Exception:
-                pass
-            last_progress_report_time = current_time
-
-    sorted_endpoints = sorted(list(remote_endpoints))
-    await ctx.info(f"[find_network_connections] Completed. {len(sorted_endpoints)} unique endpoints for '{process_name}'.")
-    return sorted_endpoints
+    records = _aggregate_network(log_data, indices_to_check, network_op_ids, group_by_process=True)
+    records.sort(key=lambda r: (-r['count'], str(r['endpoint']), r.get('pid') or 0))
+    await ctx.info(f"[find_network_connections] Completed. {len(records)} unique endpoints for '{process_name}'.")
+    return records
 
 
 @tool_decorator
@@ -966,21 +1042,21 @@ async def export_query_results(
 @tool_decorator
 async def list_network_connections(limit: int = 200, *, ctx: Context) -> List[Dict[str, Any]]:
     """
-    Lists unique network connections across ALL processes in the loaded capture.
+    Lists network connections across ALL processes in the loaded capture, enriched.
 
-    Scans every network operation (TCP/UDP Connect/Send/Receive) and returns up to
-    `limit` unique records, each with the process name, PID, operation, and remote
-    endpoint (IP:port or Hostname:port). Use this for triage to see every endpoint the
-    capture touched before drilling into a single process with find_network_connections.
+    Scans every network operation (TCP/UDP Connect/Send/Receive) and returns one record
+    per unique (process_name, PID, endpoint), ranked by event count (descending) so the
+    busiest connections appear first. Each record includes: process_name, pid, endpoint
+    (host:port), host, ip, hostname, port, the operations and inferred directions
+    (connect/send/receive), distinct results, an event count, and first/last-seen
+    timestamps. At most `limit` records are returned (the top ones by count). Use this for
+    triage, then drill into a process with find_network_connections or rank remote
+    endpoints with get_network_top_talkers.
     """
     log_data = await _check_loaded(ctx, "list_network_connections")
     await ctx.info("[list_network_connections] Scanning all network events...")
 
-    network_op_ids = {
-        log_data.get_id(IK_OPERATION, op)
-        for op in NETWORK_OPERATIONS
-        if log_data.get_id(IK_OPERATION, op) is not None
-    }
+    network_op_ids = _network_op_ids(log_data)
     if not network_op_ids:
         await ctx.warning("[list_network_connections] No network operations found in interner.")
         return []
@@ -990,32 +1066,47 @@ async def list_network_connections(limit: int = 200, *, ctx: Context) -> List[Di
     candidate_indices: List[int] = []
     for op_id in network_op_ids:
         candidate_indices.extend(log_data.op_id_index.get(op_id, []))
-    candidate_indices.sort()
 
-    seen = set()
-    results: List[Dict[str, Any]] = []
-    for idx in candidate_indices:
-        event_dict = log_data.events[idx]
-        endpoint = parse_network_endpoint(log_data.get_string(IK_PATH, event_dict.get('path_id')))
-        if not endpoint:
-            continue
-        process_name = log_data.get_string(IK_PROCESS_NAME, event_dict.get('pname_id'))
-        operation = log_data.get_string(IK_OPERATION, event_dict.get('op_id'))
-        pid = event_dict.get('pid')
-        key = (process_name, pid, operation, endpoint)
-        if key in seen:
-            continue
-        seen.add(key)
-        results.append({
-            "process_name": process_name,
-            "pid": pid,
-            "operation": operation,
-            "endpoint": endpoint,
-        })
-        if len(results) >= limit:
-            await ctx.warning(f"[list_network_connections] Result limit ({limit}) reached; output truncated.")
-            break
+    records = _aggregate_network(log_data, candidate_indices, network_op_ids, group_by_process=True)
+    records.sort(key=lambda r: (-r['count'], str(r.get('process_name')), str(r['endpoint'])))
 
-    results.sort(key=lambda r: (str(r["process_name"]), str(r["endpoint"])))
-    await ctx.info(f"[list_network_connections] Completed. {len(results)} unique records.")
-    return results
+    total = len(records)
+    if total > limit:
+        await ctx.warning(f"[list_network_connections] {total} records; returning top {limit} by event count.")
+        records = records[:limit]
+    await ctx.info(f"[list_network_connections] Completed. {len(records)} of {total} unique connections.")
+    return records
+
+
+@tool_decorator
+async def get_network_top_talkers(limit: int = 50, *, ctx: Context) -> List[Dict[str, Any]]:
+    """
+    Ranks unique remote endpoints across the WHOLE capture by network-event count.
+
+    Aggregates all network operations (TCP/UDP Connect/Send/Receive) by remote endpoint
+    (ignoring which process), returning up to `limit` endpoints sorted by event count
+    (descending). Each record includes: endpoint (host:port), host, ip, hostname, port,
+    an event count, the number of distinct processes that touched it (process_count) and
+    their names (processes), the operations and inferred directions seen, distinct
+    results, and first/last-seen timestamps.
+    """
+    log_data = await _check_loaded(ctx, "get_network_top_talkers")
+    await ctx.info("[get_network_top_talkers] Ranking remote endpoints...")
+
+    network_op_ids = _network_op_ids(log_data)
+    if not network_op_ids:
+        await ctx.warning("[get_network_top_talkers] No network operations found in interner.")
+        return []
+
+    candidate_indices: List[int] = []
+    for op_id in network_op_ids:
+        candidate_indices.extend(log_data.op_id_index.get(op_id, []))
+
+    records = _aggregate_network(log_data, candidate_indices, network_op_ids, group_by_process=False)
+    records.sort(key=lambda r: (-r['count'], str(r['endpoint'])))
+
+    total = len(records)
+    if total > limit:
+        records = records[:limit]
+    await ctx.info(f"[get_network_top_talkers] Completed. Top {len(records)} of {total} unique endpoints.")
+    return records

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -537,6 +537,47 @@ class TestParseNetworkEndpoint:
             "a:1 -> [2001:db8::1]:https") == "2001:db8::1:https"
 
 
+class TestParseNetworkEndpointParts:
+    def test_ipv4_sets_ip_not_hostname(self):
+        parts = procmon_mcp.parse_network_endpoint_parts("a:1 -> 93.184.216.34:443")
+        assert parts["endpoint"] == "93.184.216.34:443"
+        assert parts["host"] == "93.184.216.34"
+        assert parts["port"] == "443"
+        assert parts["ip"] == "93.184.216.34"
+        assert parts["hostname"] is None
+
+    def test_hostname_sets_hostname_not_ip(self):
+        parts = procmon_mcp.parse_network_endpoint_parts("a:1 -> example.com:https")
+        assert parts["hostname"] == "example.com"
+        assert parts["ip"] is None
+        assert parts["port"] == "https"
+
+    def test_ipv6_is_ip(self):
+        parts = procmon_mcp.parse_network_endpoint_parts("a:1 -> [2001:db8::1]:443")
+        assert parts["ip"] == "2001:db8::1"
+        assert parts["hostname"] is None
+
+    def test_no_match_returns_none(self):
+        assert procmon_mcp.parse_network_endpoint_parts("C:\\x.dll") is None
+
+
+class TestNetworkDirection:
+    def test_connect(self):
+        assert procmon_mcp.network_direction("TCP Connect") == "connect"
+
+    def test_send(self):
+        assert procmon_mcp.network_direction("UDP Send") == "send"
+
+    def test_receive(self):
+        assert procmon_mcp.network_direction("TCP Receive") == "receive"
+
+    def test_unknown(self):
+        assert procmon_mcp.network_direction("CreateFile") is None
+
+    def test_none(self):
+        assert procmon_mcp.network_direction(None) is None
+
+
 # --- Parser Integration Tests ---
 
 def _write_capture(path, n_events, with_stack=True):
@@ -706,3 +747,123 @@ class TestFilterExactMatch:
         res = _collect_filtered(data, filter_operation="CreateFile",
                                 filter_result="ACCESS DENIED")
         assert res == []
+
+
+# --- Enriched Network Tools Tests ---
+
+# (process_index, pid, name, operation, remote, result)
+_NET_EVENTS = [
+    (0, 1000, "chrome.exe",  "TCP Connect", "93.184.216.34:443",      "SUCCESS"),
+    (0, 1000, "chrome.exe",  "TCP Send",    "93.184.216.34:443",      "SUCCESS"),
+    (0, 1000, "chrome.exe",  "TCP Send",    "93.184.216.34:443",      "SUCCESS"),
+    (0, 1000, "chrome.exe",  "TCP Send",    "93.184.216.34:443",      "SUCCESS"),
+    (0, 1000, "chrome.exe",  "TCP Receive", "93.184.216.34:443",      "SUCCESS"),
+    (0, 1000, "chrome.exe",  "TCP Receive", "93.184.216.34:443",      "SUCCESS"),
+    (0, 1000, "chrome.exe",  "TCP Connect", "cdn.example.com:https",  "SUCCESS"),
+    (1, 2000, "svchost.exe", "UDP Send",    "192.168.1.1:domain",     "SUCCESS"),
+    (1, 2000, "svchost.exe", "UDP Send",    "192.168.1.1:domain",     "SUCCESS"),
+    (1, 2000, "svchost.exe", "UDP Receive", "192.168.1.1:domain",     "SUCCESS"),
+    (1, 2000, "svchost.exe", "UDP Receive", "192.168.1.1:domain",     "SUCCESS"),
+]
+
+
+def _write_network_capture(path):
+    parts = [
+        '<?xml version="1.0" encoding="UTF-8"?>\n<procmon>\n<processlist>\n',
+        '<process><ProcessIndex>0</ProcessIndex><ProcessId>1000</ProcessId>'
+        '<ProcessName>chrome.exe</ProcessName><ImagePath>C:\\chrome.exe</ImagePath></process>\n',
+        '<process><ProcessIndex>1</ProcessIndex><ProcessId>2000</ProcessId>'
+        '<ProcessName>svchost.exe</ProcessName><ImagePath>C:\\svchost.exe</ImagePath></process>\n',
+        '</processlist>\n<eventlist>\n',
+    ]
+    for i, (pidx, pid, name, op, remote, result) in enumerate(_NET_EVENTS):
+        parts.append(
+            '<event><ProcessIndex>%d</ProcessIndex><PID>%d</PID>'
+            '<Time_of_Day>12:00:%02d.000000</Time_of_Day>'
+            '<Operation>%s</Operation><Path>LOCAL:55000 -&gt; %s</Path>'
+            '<Result>%s</Result><Process_Name>%s</Process_Name></event>\n'
+            % (pidx, pid, i, op, remote, result, name)
+        )
+    parts.append('</eventlist>\n</procmon>\n')
+    with open(path, 'w', encoding='utf-8') as f:
+        f.write(''.join(parts))
+
+
+def _drive(coro):
+    return asyncio.run(coro)
+
+
+def _load_net(tmp_path):
+    from procmon_mcp.parser import load_procmon_xml
+    from procmon_mcp import server
+    path = str(tmp_path / "net.xml")
+    _write_network_capture(path)
+    data = load_procmon_xml(path, load_stack=False, load_extra=False)
+    server.LOADED_DATA = data
+    return data
+
+
+class TestNetworkTools:
+    def _ctx(self):
+        return _DummyContext()
+
+    def test_list_network_connections_enriched_and_ranked(self, tmp_path):
+        from procmon_mcp import tools
+        _load_net(tmp_path)
+        res = _drive(tools.list_network_connections(ctx=self._ctx()))
+        # Three unique (process, pid, endpoint) groups, ranked by count desc.
+        assert [r["endpoint"] for r in res] == [
+            "93.184.216.34:443", "192.168.1.1:domain", "cdn.example.com:https"]
+        top = res[0]
+        assert top["process_name"] == "chrome.exe" and top["pid"] == 1000
+        assert top["count"] == 6
+        assert top["directions"] == ["connect", "receive", "send"]
+        assert top["results"] == ["SUCCESS"]
+        assert top["ip"] == "93.184.216.34" and top["hostname"] is None
+        assert top["first_seen"] is not None and top["last_seen"] is not None
+
+    def test_hostname_surfaced_separately_from_ip(self, tmp_path):
+        from procmon_mcp import tools
+        _load_net(tmp_path)
+        res = _drive(tools.list_network_connections(ctx=self._ctx()))
+        host_rec = next(r for r in res if r["endpoint"] == "cdn.example.com:https")
+        assert host_rec["hostname"] == "cdn.example.com"
+        assert host_rec["ip"] is None
+        assert host_rec["port"] == "https"
+
+    def test_list_limit_keeps_top_by_count(self, tmp_path):
+        from procmon_mcp import tools
+        _load_net(tmp_path)
+        res = _drive(tools.list_network_connections(limit=1, ctx=self._ctx()))
+        assert len(res) == 1
+        assert res[0]["endpoint"] == "93.184.216.34:443"  # busiest
+
+    def test_find_network_connections_returns_records(self, tmp_path):
+        from procmon_mcp import tools
+        _load_net(tmp_path)
+        res = _drive(tools.find_network_connections("chrome.exe", ctx=self._ctx()))
+        endpoints = [r["endpoint"] for r in res]
+        assert endpoints == ["93.184.216.34:443", "cdn.example.com:https"]
+        assert res[0]["count"] == 6
+        assert res[0]["directions"] == ["connect", "receive", "send"]
+
+    def test_top_talkers_rollup_across_processes(self, tmp_path):
+        from procmon_mcp import tools
+        _load_net(tmp_path)
+        res = _drive(tools.get_network_top_talkers(ctx=self._ctx()))
+        assert [r["endpoint"] for r in res] == [
+            "93.184.216.34:443", "192.168.1.1:domain", "cdn.example.com:https"]
+        assert [r["count"] for r in res] == [6, 4, 1]
+        # Each rollup record reports how many distinct processes touched it.
+        assert res[0]["process_count"] == 1
+        assert res[0]["processes"] == ["chrome.exe (PID 1000)"]
+
+    def test_no_network_events_returns_empty(self, tmp_path):
+        from procmon_mcp import tools
+        from procmon_mcp.parser import load_procmon_xml
+        from procmon_mcp import server
+        path = str(tmp_path / "nonet.xml")
+        _write_capture(path, 5, with_stack=False)  # CreateFile events only
+        server.LOADED_DATA = load_procmon_xml(path, load_stack=False, load_extra=False)
+        assert _drive(tools.list_network_connections(ctx=self._ctx())) == []
+        assert _drive(tools.get_network_top_talkers(ctx=self._ctx())) == []


### PR DESCRIPTION
Closes #9.

## Summary

Network triage previously returned bare data — `find_network_connections` gave a list of `host:port` strings, and `list_network_connections` (from #7) gave `process/pid/operation/endpoint`. This PR adds the enrichment requested in #9 across all network tools.

## What's new

**Helpers (`helpers.py`)**
- `parse_network_endpoint_parts()` — structured `host` / `port` / `ip` / `hostname` (classifies the host as a literal IP vs DNS name via `ipaddress`).
- `network_direction()` — infers `connect` / `send` / `receive` from the operation name.

**Tools (`tools.py`)** — a shared `_aggregate_network()` builds enriched records: `endpoint`, `host`/`ip`/`hostname`/`port`, `operations`, `directions`, distinct `results`, `count`, and `first_seen`/`last_seen` (+ `_unix`).
- `find_network_connections(process_name)` → enriched per-`(pid, endpoint)` records, ranked by count. **Return shape changed** from `List[str]` to `List[dict]`.
- `list_network_connections(limit?)` → enriched per-`(process, pid, endpoint)` records ranked by count; `limit` now keeps the **busiest** (previously arbitrary order).
- `get_network_top_talkers(limit?)` → **new** tool ranking remote endpoints capture-wide by event count, with `process_count` and `processes` per endpoint.

Maps to the four asks in #9: result+direction, first-seen+count (and last-seen), hostname-alongside-IP, and a top-talkers rollup.

## Verification

- New tests: `TestParseNetworkEndpointParts`, `TestNetworkDirection`, `TestNetworkTools` (enrichment fields, hostname/IP split, count ranking + truncation, top-talkers rollup, empty-capture). **Full suite 115 passing**, with and without lxml; server import smoke OK.
- End-to-end on a real capture: the `svchost.exe → 192.168.249.2:domain` DNS traffic now reports `count: 12`, `directions: [receive, send]`, `results: [SUCCESS]`, first/last-seen, and a top-talkers entry with `process_count: 1`.

## Note (breaking)

`find_network_connections` now returns structured records instead of endpoint strings. The README and docstrings are updated; example prompts still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)