### PR TITLE
Fix get_process_lifetime to recognize Process Start (closes #14)

### DIFF
--- a/procmon_mcp/constants.py
+++ b/procmon_mcp/constants.py
@@ -15,8 +15,14 @@ PROGRESS_REPORT_SECONDS = 5.0  # Also report progress every N seconds
 # The parser will advance this date if it detects a midnight rollover.
 BASE_DATE = datetime(1970, 1, 1, tzinfo=timezone.utc)
 
-# Known operation strings
+# Known operation strings.
+# Procmon emits two distinct lifecycle events: "Process Create" is logged by the
+# PARENT (with the parent's PID, path = the child's image), while "Process Start"
+# is the process's own start (with its own PID). To find a process's own creation
+# time we must consider both, matched against the target PID.
 OP_PROCESS_CREATE = "Process Create"
+OP_PROCESS_START = "Process Start"
+PROCESS_CREATE_OPERATIONS = (OP_PROCESS_CREATE, OP_PROCESS_START)
 OP_PROCESS_EXIT = "Process Exit"
 NETWORK_OPERATIONS = {"TCP Connect", "TCP Send", "TCP Receive", "UDP Send", "UDP Receive"}
 

--- a/procmon_mcp/tools.py
+++ b/procmon_mcp/tools.py
@@ -13,7 +13,7 @@ from typing import List, Dict, Any, Optional
 from .compat import Context, PSUTIL_AVAILABLE
 from .constants import (
     PROCMON_TIMESTAMP_FORMAT, PROGRESS_REPORT_INTERVAL, PROGRESS_REPORT_SECONDS,
-    OP_PROCESS_CREATE, OP_PROCESS_EXIT, NETWORK_OPERATIONS,
+    OP_PROCESS_EXIT, PROCESS_CREATE_OPERATIONS, NETWORK_OPERATIONS,
     IK_PROCESS_NAME, IK_OPERATION, IK_PATH, IK_RESULT, IK_CATEGORY,
     IK_STACK_PATH, IK_STACK_LOCATION,
 )
@@ -683,15 +683,25 @@ async def get_timing_statistics(group_by: str = "process", *, ctx: Context) -> D
 @tool_decorator
 async def get_process_lifetime(pid: int, ctx: Context) -> Dict[str, Optional[float]]:
     """
-    Finds the first 'Process Create' and the last 'Process Exit' event timestamps (Unix float) for a given Process ID (PID).
+    Finds the process creation and the last 'Process Exit' event timestamps (Unix float) for a given Process ID (PID).
     Scans through the loaded events to find the relevant timestamps.
+
+    Procmon records a process's own start as a 'Process Start' event (with that
+    PID), whereas 'Process Create' is logged by the PARENT (with the parent's
+    PID). This tool considers both, matched against the requested PID, and uses
+    the earliest as the creation time — which is the process's own start when it
+    started during the capture.
+
     Returns a dictionary with 'create_timestamp' and 'exit_timestamp'. Values will be None if the corresponding event is not found.
     """
     log_data = await _check_loaded(ctx, "get_process_lifetime")
     await ctx.info(f"[get_process_lifetime] Starting for PID: {pid}")
     create_ts: Optional[float] = None
     exit_ts: Optional[float] = None
-    create_op_id = log_data.get_id(IK_OPERATION, OP_PROCESS_CREATE)
+    create_op_ids = [
+        oid for oid in (log_data.get_id(IK_OPERATION, op) for op in PROCESS_CREATE_OPERATIONS)
+        if oid is not None
+    ]
     exit_op_id = log_data.get_id(IK_OPERATION, OP_PROCESS_EXIT)
 
     if pid not in log_data.processes_by_pid:
@@ -705,11 +715,15 @@ async def get_process_lifetime(pid: int, ctx: Context) -> Dict[str, Optional[flo
         await ctx.info(f"[get_process_lifetime] PID {pid}: {result}")
         return result
 
-    if create_op_id is not None:
-        create_indices = log_data.op_id_index.get(create_op_id, [])
-        for idx in create_indices:
+    # Earliest "Process Start"/"Process Create" event belonging to this PID.
+    # op_id_index lists are in ascending event-index (time) order, so the first
+    # match for each op is that op's earliest; we then keep the minimum.
+    for create_op_id in create_op_ids:
+        for idx in log_data.op_id_index.get(create_op_id, []):
             if idx in pid_event_set:
-                create_ts = log_data.events[idx].get('ts')
+                ts = log_data.events[idx].get('ts')
+                if ts is not None and (create_ts is None or ts < create_ts):
+                    create_ts = ts
                 break
 
     if exit_op_id is not None:

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -961,3 +961,79 @@ class TestCaptureCache:
         from procmon_mcp import cache
         monkeypatch.setattr(cache, "CACHE_DIR", str(tmp_path / "cache"))
         assert cache.compute_key(str(tmp_path / "nope.xml"), True, True) is None
+
+
+# --- Process Lifetime Tests ---
+
+# (pid, process_name, operation, time_of_day, path) — a parent (explorer) that
+# started during the capture and creates a child, then both exit. The child's own
+# creation is a "Process Start" with the child's PID; the parent-side
+# "Process Create" carries the PARENT's PID.
+_LIFECYCLE_EVENTS = [
+    (100, "explorer.exe", "Process Start",  "12:00:00.000000", "C:\\explorer.exe"),
+    (100, "explorer.exe", "Process Create", "12:00:01.000000", "C:\\child.exe"),
+    (200, "child.exe",    "Process Start",  "12:00:02.000000", "C:\\child.exe"),
+    (200, "child.exe",    "CreateFile",     "12:00:03.000000", "C:\\data.bin"),
+    (200, "child.exe",    "Process Exit",   "12:00:04.000000", "C:\\child.exe"),
+    (100, "explorer.exe", "Process Exit",   "12:00:05.000000", "C:\\explorer.exe"),
+]
+
+
+def _write_lifecycle_capture(path):
+    parts = [
+        '<?xml version="1.0" encoding="UTF-8"?>\n<procmon>\n<processlist>\n',
+        '<process><ProcessIndex>0</ProcessIndex><ProcessId>100</ProcessId>'
+        '<ProcessName>explorer.exe</ProcessName><ImagePath>C:\\explorer.exe</ImagePath></process>\n',
+        '<process><ProcessIndex>1</ProcessIndex><ProcessId>200</ProcessId>'
+        '<ProcessName>child.exe</ProcessName><ImagePath>C:\\child.exe</ImagePath></process>\n',
+        '</processlist>\n<eventlist>\n',
+    ]
+    for pid, name, op, tod, p in _LIFECYCLE_EVENTS:
+        idx = 0 if pid == 100 else 1
+        parts.append(
+            '<event><ProcessIndex>%d</ProcessIndex><PID>%d</PID>'
+            '<Time_of_Day>%s</Time_of_Day><Operation>%s</Operation>'
+            '<Path>%s</Path><Result>SUCCESS</Result><Process_Name>%s</Process_Name></event>\n'
+            % (idx, pid, tod, op, p, name)
+        )
+    parts.append('</eventlist>\n</procmon>\n')
+    with open(path, 'w', encoding='utf-8') as f:
+        f.write(''.join(parts))
+
+
+# 1970-01-01 epoch + HH:MM:SS, matching the parser's BASE_DATE.
+def _tod(h, m, s):
+    return h * 3600 + m * 60 + s
+
+
+class TestProcessLifetime:
+    def _load(self, tmp_path):
+        from procmon_mcp.parser import load_procmon_xml
+        from procmon_mcp import server
+        path = str(tmp_path / "life.xml")
+        _write_lifecycle_capture(path)
+        server.LOADED_DATA = load_procmon_xml(path, load_stack=False, load_extra=False)
+
+    def test_child_create_uses_process_start(self, tmp_path):
+        # Regression: the child has no "Process Create" with its own PID, only
+        # "Process Start". create_timestamp must come from that, not be None.
+        from procmon_mcp import tools
+        self._load(tmp_path)
+        r = _drive(tools.get_process_lifetime(200, _DummyContext()))
+        assert r["create_timestamp"] == _tod(12, 0, 2)
+        assert r["exit_timestamp"] == _tod(12, 0, 4)
+
+    def test_parent_prefers_own_start_over_child_create(self, tmp_path):
+        # explorer has both its own "Process Start" (12:00:00) and a parent-side
+        # "Process Create" of the child (12:00:01); the earliest (its start) wins.
+        from procmon_mcp import tools
+        self._load(tmp_path)
+        r = _drive(tools.get_process_lifetime(100, _DummyContext()))
+        assert r["create_timestamp"] == _tod(12, 0, 0)
+        assert r["exit_timestamp"] == _tod(12, 0, 5)
+
+    def test_unknown_pid_returns_nones(self, tmp_path):
+        from procmon_mcp import tools
+        self._load(tmp_path)
+        r = _drive(tools.get_process_lifetime(999, _DummyContext()))
+        assert r == {"create_timestamp": None, "exit_timestamp": None}


### PR DESCRIPTION
Closes #14. Found during thorough live testing of the MCP server.

## Problem

`get_process_lifetime(pid)` returned `create_timestamp: null` for processes that started during the capture. Procmon records a process's own start as **`Process Start`** (with that PID), while **`Process Create`** is logged by the **parent** (with the parent's PID). The tool only matched `Process Create` against the requested PID, so it never found a process's own creation. `exit_timestamp` worked because `Process Exit` carries the process's own PID.

## Fix

Add `OP_PROCESS_START` / `PROCESS_CREATE_OPERATIONS` and have `get_process_lifetime` consider **both** ops matched against the PID, using the **earliest** timestamp. A process always starts before it creates any child, so its own `Process Start` wins when present; an already-running parent (no `Process Start`) falls back to its first `Process Create`, as before.

## Verification

- Real captures: `7zG.exe` create `null` → `11:59:42.747682`; `Notepad.exe` create `null` → `10:08:32.895744`. Exit timestamps unchanged.
- New `TestProcessLifetime`: child-uses-`Process Start`, parent-prefers-own-start-over-child-create, unknown-PID. **126 tests pass**, with and without lxml; import smoke OK.