### PR TITLE
Release 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-06-23
+
+### Fixed
+- `get_process_lifetime` returned `create_timestamp: null` for processes that
+  started during the capture. Procmon records a process's own start as a
+  `Process Start` event (with that PID), whereas `Process Create` is logged by
+  the parent (with the parent's PID), so matching only `Process Create` against
+  the requested PID never found the process's own creation. The tool now
+  considers both operations and uses the earliest, so a process's own
+  `Process Start` is used when present. (#14)
+
 ## [0.2.0] - 2026-06-23
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "procmon-mcp"
-version = "0.2.0"
+version = "0.2.1"
 description = "Model Context Protocol (MCP) server for analysing Process Monitor (Procmon) XML log files."
 readme = "README.md"
 requires-python = ">=3.7"


### PR DESCRIPTION
Cut **0.2.1** for the `get_process_lifetime` fix (#14).

- Bump `pyproject.toml` `0.2.0` → `0.2.1`.
- Add a `[0.2.1]` changelog entry under **Fixed**.

Docs + version metadata only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)