### PR TITLE
Fix streamable-http startup: set host/port via settings, not run() kwargs

### DIFF
--- a/procmon_mcp/cli.py
+++ b/procmon_mcp/cli.py
@@ -107,9 +107,19 @@ def main_execution(args):
             server_started = True
 
         elif transport == "streamable-http":
+            if hasattr(server.mcp, 'settings'):
+                logger.info("Configuring MCP for Streamable HTTP transport...")
+                server.mcp.settings.host = args.mcp_host
+                server.mcp.settings.port = args.mcp_port
+                log_level = logging.DEBUG if args.debug else logging.INFO
+                mcp_log_level_name = logging.getLevelName(log_level)
+                server.mcp.settings.log_level = mcp_log_level_name.lower()
+                logger.info(f"  MCP Host: {server.mcp.settings.host}, Port: {server.mcp.settings.port}")
+            else:
+                logger.warning("MCP object lacks 'settings'; cannot configure Streamable HTTP via arguments.")
             logger.info(f"Starting MCP server with Streamable HTTP transport on "
                         f"http://{args.mcp_host}:{args.mcp_port}/mcp")
-            server.mcp.run(transport="streamable-http", host=args.mcp_host, port=args.mcp_port)
+            server.mcp.run(transport="streamable-http")
             server_started = True
 
         else:


### PR DESCRIPTION
Starting the server with `--transport streamable-http` crashes immediately:

```
CRITICAL - Failed during server startup or execution: FastMCP.run() got an unexpected keyword argument 'host'
```

The streamable-http branch passes `host=`/`port=` to `server.mcp.run()`, but the MCP SDK's signature is `run(transport, mount_path)`. Host and port belong on `server.mcp.settings`, which the SSE branch above already sets. This change makes streamable-http follow that same pattern.

`stdio` (the default transport) is unaffected, and the 0.2.0 parsed-capture cache is untouched.

## Verification

On mcp 1.28.0 / uvicorn 0.49.0 / starlette 1.3.1 (Python 3.12):

- Before: `procmon-mcp --transport streamable-http` raises the TypeError above and exits.
- After: uvicorn binds and an MCP client `get_status` call over streamable-http returns successfully.
