### PR TITLE
Release 0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-06-23
+
+### Fixed
+- `--transport streamable-http` crashed immediately with
+  `FastMCP.run() got an unexpected keyword argument 'host'`. The MCP SDK's
+  `run()` signature is `run(transport, mount_path)`; host and port belong on
+  `mcp.settings`. The Streamable HTTP branch now configures host/port/log level
+  via `settings` (matching the SSE branch) before calling `run()`. `stdio`
+  (the default) was unaffected. (#17)
+
 ## [0.2.1] - 2026-06-23
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "procmon-mcp"
-version = "0.2.1"
+version = "0.2.2"
 description = "Model Context Protocol (MCP) server for analysing Process Monitor (Procmon) XML log files."
 readme = "README.md"
 requires-python = ">=3.7"


### PR DESCRIPTION
Cut **0.2.2** for the Streamable HTTP startup fix (#17).

- Bump `pyproject.toml` `0.2.1` → `0.2.2`.
- Add a `[0.2.2]` changelog entry under **Fixed**.

Docs + version metadata only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)