### PR TITLE
Add close_file tool to unload the current capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`close_file`** tool — closes (unloads) the currently loaded capture and frees
+  its memory, so a client can explicitly release a file before opening another or
+  leave the server idle. Analysis tools refuse until another file is loaded; the
+  on-disk cache is left intact. `get_status` now lists `close_file` as an
+  available action while a file is loaded.
+
 ## [0.2.2] - 2026-06-23
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -266,7 +266,8 @@ under a second.
 | Tool | Description |
 |------|-------------|
 | `get_status()` | Returns the current server state — whether a file is loaded, loading progress, memory usage, and available actions. **Call this first.** |
-| `load_file(file_path, no_stack_traces?, no_extra_data?, no_cache?)` | Loads a Procmon XML file (.xml, .gz, .bz2, .xz) for analysis. Uses the parsed-capture cache for near-instant reloads (`from_cache` in the response says whether it was used). Provides progress feedback. Replaces any previously loaded data. |
+| `load_file(file_path, no_stack_traces?, no_extra_data?, no_cache?)` | Loads a Procmon XML file (.xml, .gz, .bz2, .xz) for analysis. Uses the parsed-capture cache for near-instant reloads (`from_cache` in the response says whether it was used). Set `no_cache: true` to bypass the cache. Provides progress feedback. Replaces any previously loaded data. |
+| `close_file()` | Closes (unloads) the currently loaded capture and frees its memory. Analysis tools are unavailable until another file is opened with `load_file`. Does not remove the on-disk cache. |
 | `clear_cache()` | Removes all on-disk parsed-capture caches. Reclaims disk space and forces a clean re-parse on the next load. Does not affect currently loaded data. |
 
 ### Data Retrieval Tools

--- a/procmon_mcp/tools.py
+++ b/procmon_mcp/tools.py
@@ -55,6 +55,7 @@ async def get_status(ctx: Context) -> Dict[str, Any]:
             status["available_actions"] = [
                 "All analysis tools (query_events, list_processes, etc.)",
                 "load_file (to load a different file)",
+                "close_file (to unload the current file)",
             ]
 
             # Memory usage
@@ -195,6 +196,41 @@ async def load_file(
         raise RuntimeError(f"Error loading file: {e}")
     finally:
         server.LOADING_IN_PROGRESS = False
+
+
+@tool_decorator
+async def close_file(ctx: Context) -> Dict[str, Any]:
+    """
+    Closes (unloads) the currently loaded capture and frees its memory.
+
+    After closing, the analysis tools are unavailable until another file is
+    opened with load_file. This does not remove the on-disk parsed-capture cache
+    (use clear_cache for that), so re-opening the same file is still fast.
+    Returns whether a file was actually open and, if so, its name.
+    """
+    await ctx.info("[close_file] Closing currently loaded capture...")
+
+    if server.LOADING_IN_PROGRESS:
+        await ctx.error("[close_file] A file is currently being loaded; cannot close now.")
+        raise RuntimeError("A file load is in progress; please wait before closing.")
+
+    if not server.LOADED_DATA or not server.LOADED_DATA.is_loaded():
+        await ctx.info("[close_file] No file was loaded.")
+        return {
+            "success": True,
+            "was_loaded": False,
+            "message": "No file was loaded. Use 'load_file' to open a Procmon XML capture.",
+        }
+
+    closed_filename = server.LOADED_DATA.loaded_filename
+    server.LOADED_DATA = None
+    await ctx.info(f"[close_file] Closed '{closed_filename}'.")
+    return {
+        "success": True,
+        "was_loaded": True,
+        "closed_filename": closed_filename,
+        "message": f"Closed '{closed_filename}'. Use 'load_file' to open another capture.",
+    }
 
 
 @tool_decorator

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -963,6 +963,42 @@ class TestCaptureCache:
         assert cache.compute_key(str(tmp_path / "nope.xml"), True, True) is None
 
 
+# --- close_file Tests ---
+
+class TestCloseFile:
+    def test_close_unloads_data(self, tmp_path):
+        from procmon_mcp.parser import load_procmon_xml
+        from procmon_mcp import server, tools
+        path = str(tmp_path / "c.xml")
+        _write_capture(path, 5, with_stack=False)
+        server.LOADED_DATA = load_procmon_xml(path, False, False)
+        assert server.LOADED_DATA.is_loaded()
+
+        r = _drive(tools.close_file(_DummyContext()))
+        assert r["success"] is True
+        assert r["was_loaded"] is True
+        assert r["closed_filename"] == "c.xml"
+        assert server.LOADED_DATA is None
+
+    def test_close_when_nothing_loaded(self, tmp_path):
+        from procmon_mcp import server, tools
+        server.LOADED_DATA = None
+        r = _drive(tools.close_file(_DummyContext()))
+        assert r["success"] is True
+        assert r["was_loaded"] is False
+
+    def test_analysis_tool_unavailable_after_close(self, tmp_path):
+        from procmon_mcp.parser import load_procmon_xml
+        from procmon_mcp import server, tools
+        path = str(tmp_path / "c2.xml")
+        _write_capture(path, 5, with_stack=False)
+        server.LOADED_DATA = load_procmon_xml(path, False, False)
+        _drive(tools.close_file(_DummyContext()))
+        # With nothing loaded, analysis tools must refuse via _check_loaded.
+        with pytest.raises(RuntimeError):
+            _drive(tools.list_processes(ctx=_DummyContext()))
+
+
 # --- Process Lifetime Tests ---
 
 # (pid, process_name, operation, time_of_day, path) — a parent (explorer) that


### PR DESCRIPTION
## Summary

Adds an explicit **`close_file`** tool to unload the currently loaded capture and free its memory. After closing, the analysis tools refuse (via `_check_loaded`) until another file is opened with `load_file`; the on-disk parsed-capture cache is left intact so re-opening stays fast. `get_status` now lists `close_file` as an available action while a file is loaded.

## Context — what already existed

Most of the requested file-management surface was already present, so this PR only adds the missing close/unload:

- **Start without a file** — the server starts dataless when `--input-file` is omitted.
- **Open an xz/xml file by path** — `load_file(file_path, …)` (`.xml/.gz/.bz2/.xz`).
- **Open another file** — `load_file` replaces the loaded data.
- **Cache control per load** — `load_file(..., no_cache=true)`; plus `clear_cache`.
- **Check status / what's open** — `get_status`.

## Verified

End-to-end: start dataless → `load_file` → `get_status` (loaded, lists `close_file`) → `close_file` → `get_status` (not loaded) → analysis tools refuse → `load_file` a different capture succeeds.

`TestCloseFile` covers: unloads data, no-op when nothing loaded, analysis tool refuses after close. **129 tests pass**, with and without lxml.

Changelog entry under `[Unreleased]`; can cut a `0.3.0` release on merge (new tool → minor bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)