### PR TITLE
Release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-06-23
+
 ### Added
 - **`close_file`** tool — closes (unloads) the currently loaded capture and frees
   its memory, so a client can explicitly release a file before opening another or

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "procmon-mcp"
-version = "0.2.2"
+version = "0.3.0"
 description = "Model Context Protocol (MCP) server for analysing Process Monitor (Procmon) XML log files."
 readme = "README.md"
 requires-python = ">=3.7"


### PR DESCRIPTION
Cut **0.3.0** for the new `close_file` tool (#19).

- Bump `pyproject.toml` `0.2.2` → `0.3.0` (new tool → minor bump).
- Date the `[0.3.0]` changelog entry.

Docs + version metadata only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)