### PR TITLE
Repair mojibake non-ASCII names and add filter_pid (closes #21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.3.0] - 2026-06-23
+## [0.3.1] - 2026-06-23
+
+### Added
+- **`filter_pid`** on `query_events` and `export_query_results` — select a single
+  process by its numeric PID (index-backed). Useful when a process name is hard to
+  type exactly, e.g. non-ASCII names. (#21)
+
+### Fixed
+- **Non-ASCII process/path names** were unreadable mojibake (e.g.
+  `æ¸©åº¦ã¹ã¤ãã.exe` instead of `温度スイッチ.exe`) and couldn't be matched by
+  `filter_process`. Procmon's XML export double-encodes such text (UTF-8 bytes →
+  Latin-1 → UTF-8); the parser now repairs this on load for process names, paths,
+  image paths, command lines, owners, descriptions, and event detail. The repair
+  is conservative (only strings with the exact double-encoding fingerprint are
+  touched; ASCII and correctly-stored names are unchanged). The parsed-capture
+  cache version was bumped so existing caches re-parse. (#21)
 
 ### Added
 - **`close_file`** tool — closes (unloads) the currently loaded capture and frees

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ under a second.
 | `get_metadata()` | Returns basic metadata (filename, type, event/process counts). |
 | `list_processes()` | Lists unique processes (PID, name, image path, parent PID) from the process list section. |
 | `get_process_details(pid)` | Returns detailed properties for a specific process by PID. |
-| `query_events(...)` | Queries events with flexible filters — by process, operation, result, path (contains/regex), detail (regex), timestamp range, and stack module path. Returns event summaries with index. |
+| `query_events(...)` | Queries events with flexible filters — by process, **PID** (`filter_pid`), operation, result, path (contains/regex), detail (regex), timestamp range, and stack module path. Returns event summaries with index. |
 | `get_event_details(event_index)` | Returns all properties for a specific event by its index. |
 | `get_event_stack_trace(event_index)` | Returns the call stack for a specific event (module path, location, address). |
 
@@ -394,6 +394,7 @@ For filters not backed by an index (e.g., regex, path contains, stack module pat
 - **Memory usage**: Whilst optimised with string interning, loading extremely large XML files (millions of events with stack traces) can consume significant RAM. Use `--no-stack-traces` and `--no-extra-data` for very large files.
 - **Loading time**: Parsing and optimising large XML files takes time, particularly compressed ones. Progress is reported during loading. Reloading an unchanged file is near-instant thanks to the [parsed-capture cache](#parsed-capture-cache); only the first parse pays the full cost.
 - **XML structure**: Relies on the standard Procmon XML export structure. Malformed or non-standard XML will likely cause parsing errors.
+- **Non-ASCII names**: Procmon's XML export double-encodes non-ASCII process/path names (e.g. Japanese filenames). ProcmonMCP detects and repairs this on load so names are readable and matchable by their true value; if a process name is still awkward to type exactly, filter by `filter_pid` instead.
 - **Stack traces**: Stack trace quality depends on what Procmon resolved and included in the XML export. Requires running Procmon with symbols configured correctly.
 - **Single file at a time**: Only one file can be loaded at any given time. Loading a new file replaces the previous data.
 

--- a/procmon_mcp/__init__.py
+++ b/procmon_mcp/__init__.py
@@ -19,7 +19,7 @@ from .helpers import (
     _compile_safe_regex, _strip_namespace, _find_child_ignore_ns,
     _find_text_ignore_ns, find_text_func, _clear_elem,
     _parse_timestamp_str, _format_bytes, parse_network_endpoint,
-    parse_network_endpoint_parts, network_direction,
+    parse_network_endpoint_parts, network_direction, repair_mojibake,
 )
 
 # Data models

--- a/procmon_mcp/cache.py
+++ b/procmon_mcp/cache.py
@@ -32,7 +32,8 @@ logger = logging.getLogger(__name__)
 
 # Bump when the serialized structures or parser output change in an
 # incompatible way; old entries will then be ignored.
-CACHE_VERSION = 1
+# v2: parser now repairs double-encoded (mojibake) non-ASCII names.
+CACHE_VERSION = 2
 
 CACHE_DIR = os.path.join(os.path.expanduser("~"), ".procmonmcp", "cache")
 

--- a/procmon_mcp/filters.py
+++ b/procmon_mcp/filters.py
@@ -22,6 +22,7 @@ async def _iter_filtered_event_indices(
     ctx: Context,
     # Filters
     filter_process: Optional[str] = None,
+    filter_pid: Optional[int] = None,
     filter_operation: Optional[str] = None,
     filter_result: Optional[str] = None,
     filter_path_contains: Optional[str] = None,
@@ -153,6 +154,16 @@ async def _iter_filtered_event_indices(
             index_used = True
             if not candidate_indices:
                 await ctx.info(f"Filter Index: No events match Operation filter '{filter_operation}'.")
+                return
+        if filter_pid is not None:
+            this_pid_indices = set(log_data.pid_index.get(filter_pid, []))
+            if candidate_indices is None:
+                candidate_indices = this_pid_indices
+            else:
+                candidate_indices.intersection_update(this_pid_indices)
+            index_used = True
+            if not candidate_indices:
+                await ctx.info(f"Filter Index: No events match PID filter {filter_pid}.")
                 return
 
         # Determine iterator and total scan count

--- a/procmon_mcp/helpers.py
+++ b/procmon_mcp/helpers.py
@@ -61,6 +61,30 @@ def _find_text_ignore_ns(elem: ET_impl.Element, tag_name: str) -> Optional[str]:
 find_text_func = _find_text_ignore_ns
 
 
+def repair_mojibake(s: Optional[str]) -> Optional[str]:
+    """Repairs text double-encoded by Procmon's XML export.
+
+    Procmon exports non-ASCII names by taking the real UTF-8 bytes, treating each
+    byte as Latin-1, and UTF-8-encoding again. The result decodes to mojibake
+    (e.g. the bytes for ``温度スイッチ.exe`` come through as ``æ¸©åº¦…``). Undo it by
+    re-encoding the string as Latin-1 (recovering the original bytes) and decoding
+    those as UTF-8.
+
+    This is conservative: it only repairs strings whose every codepoint is in the
+    Latin-1 range AND whose Latin-1 bytes form valid (multi-byte) UTF-8 — the exact
+    fingerprint of the double-encoding. Pure-ASCII text and correctly-stored names
+    (e.g. ``café.exe``, whose ``é`` is not valid standalone UTF-8) are returned
+    unchanged.
+    """
+    if not s or s.isascii():
+        return s
+    try:
+        repaired = s.encode("latin-1").decode("utf-8")
+    except (UnicodeEncodeError, UnicodeDecodeError):
+        return s
+    return repaired if repaired != s else s
+
+
 def _clear_elem(elem: ET_impl.Element):
     """Helper to clear element memory using lxml/ET specific methods."""
     elem.clear()

--- a/procmon_mcp/models.py
+++ b/procmon_mcp/models.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from typing import List, Dict, Any, Optional
 
 from .compat import ET_impl
-from .helpers import find_text_func
+from .helpers import find_text_func, repair_mojibake
 
 logger = logging.getLogger(__name__)
 
@@ -154,13 +154,14 @@ class ProcessInfo:
         data['is_virtualized'] = cls._safe_text_to_bool(find_text_func(elem, 'IsVirtualized'))
         data['is_64bit'] = cls._safe_text_to_bool(find_text_func(elem, 'Is64bit'))
         data['integrity'] = find_text_func(elem, 'Integrity')
-        data['owner'] = find_text_func(elem, 'Owner')
-        data['process_name'] = find_text_func(elem, 'ProcessName')
-        data['image_path'] = find_text_func(elem, 'ImagePath')
-        data['command_line'] = find_text_func(elem, 'CommandLine')
-        data['company_name'] = find_text_func(elem, 'CompanyName')
+        # Repair names/paths double-encoded by Procmon's XML export (non-ASCII only).
+        data['owner'] = repair_mojibake(find_text_func(elem, 'Owner'))
+        data['process_name'] = repair_mojibake(find_text_func(elem, 'ProcessName'))
+        data['image_path'] = repair_mojibake(find_text_func(elem, 'ImagePath'))
+        data['command_line'] = repair_mojibake(find_text_func(elem, 'CommandLine'))
+        data['company_name'] = repair_mojibake(find_text_func(elem, 'CompanyName'))
         data['version'] = find_text_func(elem, 'Version')
-        data['description'] = find_text_func(elem, 'Description')
+        data['description'] = repair_mojibake(find_text_func(elem, 'Description'))
         return cls(**data)
 
 

--- a/procmon_mcp/parser.py
+++ b/procmon_mcp/parser.py
@@ -18,7 +18,7 @@ from .constants import (
     IK_PROCESS_NAME, IK_OPERATION, IK_PATH, IK_RESULT, IK_CATEGORY,
     IK_STACK_PATH, IK_STACK_LOCATION,
 )
-from .helpers import find_text_func, _strip_namespace, _find_child_ignore_ns, _clear_elem, _format_bytes
+from .helpers import find_text_func, _strip_namespace, _find_child_ignore_ns, _clear_elem, _format_bytes, repair_mojibake
 from .models import StringInterner, StackFrame, ProcessInfo, ProcmonLogData
 from . import cache
 
@@ -233,7 +233,7 @@ def _parse_xml_stream_for_loading(
                             'seq': ProcessInfo._safe_text_to_int(find_text_func(elem, 'SequenceNumber')),
                             'tid': ProcessInfo._safe_text_to_int(find_text_func(elem, 'ThreadId')),
                             'ppid': ProcessInfo._safe_text_to_int(find_text_func(elem, 'ParentPID')),
-                            'detail': find_text_func(elem, 'Detail'),
+                            'detail': repair_mojibake(find_text_func(elem, 'Detail')),
                             'dur': None,
                         }
                         duration_text = find_text_func(elem, 'Duration')
@@ -244,7 +244,7 @@ def _parse_xml_stream_for_loading(
                                 pass
 
                         # Process name fallback logic
-                        process_name_str = find_text_func(elem, 'Process_Name')
+                        process_name_str = repair_mojibake(find_text_func(elem, 'Process_Name'))
                         if process_name_str is None:
                             process_index = ProcessInfo._safe_text_to_int(find_text_func(elem, 'ProcessIndex'))
                             if process_index is not None:
@@ -259,7 +259,7 @@ def _parse_xml_stream_for_loading(
                         # String interning
                         opt_event['pname_id'] = interners[IK_PROCESS_NAME].get_id(process_name_str)
                         opt_event['op_id'] = interners[IK_OPERATION].get_id(find_text_func(elem, 'Operation'))
-                        opt_event['path_id'] = interners[IK_PATH].get_id(find_text_func(elem, 'Path'))
+                        opt_event['path_id'] = interners[IK_PATH].get_id(repair_mojibake(find_text_func(elem, 'Path')))
                         opt_event['res_id'] = interners[IK_RESULT].get_id(find_text_func(elem, 'Result'))
                         opt_event['cat_id'] = interners[IK_CATEGORY].get_id(find_text_func(elem, 'Category'))
 

--- a/procmon_mcp/tools.py
+++ b/procmon_mcp/tools.py
@@ -295,7 +295,8 @@ async def get_loaded_file_summary(ctx: Context) -> Dict[str, Any]:
 
 @tool_decorator
 async def query_events(
-    filter_process: Optional[str] = None, filter_operation: Optional[str] = None,
+    filter_process: Optional[str] = None, filter_pid: Optional[int] = None,
+    filter_operation: Optional[str] = None,
     filter_result: Optional[str] = None, filter_path_contains: Optional[str] = None,
     filter_process_contains: Optional[str] = None, filter_start_time: Optional[Any] = None,
     filter_end_time: Optional[Any] = None, filter_path_regex: Optional[str] = None,
@@ -306,12 +307,14 @@ async def query_events(
 ) -> List[Dict[str, Any]]:
     """
     Queries events from the optimized in-memory data, applying multiple filters (AND logic).
-    Uses indices for Process Name and Operation filters if available.
+    Uses indices for Process Name, PID, and Operation filters if available.
     Returns a list of event summaries (dictionary) for matching events, up to the specified limit.
     Each summary includes the event index, timestamp, process name, PID, operation, path, and result.
     Use 'get_event_details' with the 'event_index' from the summary to retrieve full event details.
 
     Filter Notes:
+    - filter_pid selects a single process by its numeric PID (exact). Useful when a process name
+      is hard to type exactly (e.g. non-ASCII names).
     - Exact match filters (filter_process, filter_operation, filter_result) use case-sensitive matching on the full string.
     - Contains filters (filter_path_contains, filter_process_contains, filter_stack_module_path) perform case-insensitive substring checks. They do NOT support OR logic via '|'.
     - Regex filters (filter_path_regex, filter_process_regex, filter_detail_regex) use Python's 're' module with IGNORECASE. Use these for complex patterns, including OR logic (e.g., "value1|value2"). Remember to escape special regex characters if matching literally (e.g., use '\\.' to match a period).
@@ -333,7 +336,7 @@ async def query_events(
     try:
         event_indices_iterator = _iter_filtered_event_indices(
             log_data=log_data, ctx=ctx,
-            filter_process=filter_process, filter_operation=filter_operation,
+            filter_process=filter_process, filter_pid=filter_pid, filter_operation=filter_operation,
             filter_result=filter_result, filter_path_contains=filter_path_contains,
             filter_process_contains=filter_process_contains, filter_start_time=filter_start_time,
             filter_end_time=filter_end_time, filter_path_regex=filter_path_regex,
@@ -978,7 +981,8 @@ async def find_network_connections(process_name: str, *, ctx: Context) -> List[D
 async def export_query_results(
     output_file: str,
     output_format: str = 'csv',
-    filter_process: Optional[str] = None, filter_operation: Optional[str] = None,
+    filter_process: Optional[str] = None, filter_pid: Optional[int] = None,
+    filter_operation: Optional[str] = None,
     filter_result: Optional[str] = None, filter_path_contains: Optional[str] = None,
     filter_process_contains: Optional[str] = None, filter_start_time: Optional[Any] = None,
     filter_end_time: Optional[Any] = None, filter_path_regex: Optional[str] = None,
@@ -1041,7 +1045,7 @@ async def export_query_results(
         await ctx.info("[export_query_results] Filtering events...")
         event_indices_iterator = _iter_filtered_event_indices(
             log_data=log_data, ctx=ctx,
-            filter_process=filter_process, filter_operation=filter_operation,
+            filter_process=filter_process, filter_pid=filter_pid, filter_operation=filter_operation,
             filter_result=filter_result, filter_path_contains=filter_path_contains,
             filter_process_contains=filter_process_contains, filter_start_time=filter_start_time,
             filter_end_time=filter_end_time, filter_path_regex=filter_path_regex,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "procmon-mcp"
-version = "0.3.0"
+version = "0.3.1"
 description = "Model Context Protocol (MCP) server for analysing Process Monitor (Procmon) XML log files."
 readme = "README.md"
 requires-python = ">=3.7"

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1073,3 +1073,104 @@ class TestProcessLifetime:
         self._load(tmp_path)
         r = _drive(tools.get_process_lifetime(999, _DummyContext()))
         assert r == {"create_timestamp": None, "exit_timestamp": None}
+
+
+# --- Mojibake Repair Tests ---
+
+# Bytes as they appear in a Procmon XML export of the name "温度スイッチ.exe":
+# the real UTF-8 bytes were re-encoded (Latin-1 -> UTF-8) by the exporter, so a
+# correct UTF-8 parse yields mojibake. This is what the parser reads.
+_DOUBLE_ENCODED_BYTES = bytes.fromhex(
+    "c3a6c2b8c2a9c3a5c2bac2a6c3a3c282c2b9c3a3c282c2a4c3a3c283c283c3a3c283c2812e657865"
+)
+_MOJIBAKE = _DOUBLE_ENCODED_BYTES.decode("utf-8")
+_TRUE_NAME = "温度スイッチ.exe"
+
+
+class TestRepairMojibake:
+    def test_repairs_double_encoded(self):
+        assert procmon_mcp.repair_mojibake(_MOJIBAKE) == _TRUE_NAME
+
+    def test_ascii_unchanged(self):
+        assert procmon_mcp.repair_mojibake("svchost.exe") == "svchost.exe"
+
+    def test_correctly_encoded_latin1_name_preserved(self):
+        # café.exe is valid UTF-8; 'é' is not a valid standalone UTF-8 sequence,
+        # so the repair is a no-op (not a false positive).
+        assert procmon_mcp.repair_mojibake("café.exe") == "café.exe"
+
+    def test_native_cjk_preserved(self):
+        # Correctly-stored CJK has codepoints > U+00FF; not Latin-1-encodable, left as-is.
+        assert procmon_mcp.repair_mojibake("温度.exe") == "温度.exe"
+
+    def test_mixed_ascii_and_double_encoded(self):
+        assert procmon_mcp.repair_mojibake("C:\\Malware\\" + _MOJIBAKE) == "C:\\Malware\\" + _TRUE_NAME
+
+    def test_none_and_empty(self):
+        assert procmon_mcp.repair_mojibake(None) is None
+        assert procmon_mcp.repair_mojibake("") == ""
+
+
+class TestMojibakeParsing:
+    def _write(self, path):
+        # Placeholder NAME is replaced by the raw double-encoded bytes after encoding.
+        xml = (
+            '<?xml version="1.0" encoding="UTF-8"?>\n<procmon>\n<processlist>\n'
+            '<process><ProcessIndex>0</ProcessIndex><ProcessId>1112</ProcessId>'
+            '<ProcessName>NAME</ProcessName><ImagePath>C:\\Malware\\NAME</ImagePath></process>\n'
+            '</processlist>\n<eventlist>\n'
+            '<event><ProcessIndex>0</ProcessIndex><PID>1112</PID>'
+            '<Time_of_Day>12:00:00.000000</Time_of_Day><Operation>CreateFile</Operation>'
+            '<Path>C:\\Malware\\NAME</Path><Result>SUCCESS</Result>'
+            '<Process_Name>NAME</Process_Name></event>\n'
+            '</eventlist>\n</procmon>\n'
+        ).encode("utf-8").replace(b"NAME", _DOUBLE_ENCODED_BYTES)
+        with open(path, "wb") as f:
+            f.write(xml)
+
+    def test_double_encoded_names_repaired_on_load(self, tmp_path):
+        from procmon_mcp.parser import load_procmon_xml
+        from procmon_mcp.constants import IK_PROCESS_NAME, IK_PATH
+        path = str(tmp_path / "moji.xml")
+        self._write(path)
+        data = load_procmon_xml(path, load_stack=False, load_extra=False)
+
+        # Event-level interned process name and path are repaired.
+        ev_names = {data.get_string(IK_PROCESS_NAME, k) for k in data.pname_id_index}
+        assert _TRUE_NAME in ev_names
+        ev_paths = {data.get_string(IK_PATH, k) for k in data.path_id_index}
+        assert "C:\\Malware\\" + _TRUE_NAME in ev_paths
+
+        # Process-list (Pass 1) name and image path are repaired.
+        proc = data.processes_by_pid[1112]
+        assert proc.process_name == _TRUE_NAME
+        assert proc.image_path == "C:\\Malware\\" + _TRUE_NAME
+
+
+# --- filter_pid Tests ---
+
+class TestFilterByPid:
+    def _load(self, tmp_path):
+        from procmon_mcp.parser import load_procmon_xml
+        path = str(tmp_path / "pid.xml")
+        _write_network_capture(path)  # chrome PID 1000 (7 events), svchost PID 2000 (4)
+        return load_procmon_xml(path, load_stack=False, load_extra=False)
+
+    def test_filter_pid_isolates_process(self, tmp_path):
+        data = self._load(tmp_path)
+        res = _collect_filtered(data, filter_pid=1000)
+        assert len(res) == 7
+        assert all(data.events[i]["pid"] == 1000 for i in res)
+
+    def test_filter_pid_other_process(self, tmp_path):
+        data = self._load(tmp_path)
+        assert len(_collect_filtered(data, filter_pid=2000)) == 4
+
+    def test_filter_pid_absent_returns_none(self, tmp_path):
+        data = self._load(tmp_path)
+        assert _collect_filtered(data, filter_pid=9999) == []
+
+    def test_filter_pid_combined_with_operation(self, tmp_path):
+        data = self._load(tmp_path)
+        res = _collect_filtered(data, filter_pid=1000, filter_operation="TCP Send")
+        assert len(res) == 3  # chrome has 3 TCP Send events


### PR DESCRIPTION
Closes #21.

## Two parts

### 1. Repair double-encoded (mojibake) names
Procmon's XML export double-encodes non-ASCII text (real UTF-8 bytes → Latin-1 → UTF-8), so a name like `温度スイッチ.exe` arrives as `æ¸©åº¦ã¹ã¤ãã.exe` — unreadable, and unmatchable by `filter_process` (it even contains non-printable control codepoints).

New `helpers.repair_mojibake()` undoes it (`s.encode("latin-1").decode("utf-8")`), applied on load to **process names, paths, image paths, command lines, owners, descriptions, and event detail**. It's conservative — only strings whose every codepoint is Latin-1 **and** whose bytes form valid multi-byte UTF-8 (the double-encoding fingerprint) are repaired; ASCII and correctly-stored names (e.g. `café.exe`, native CJK) are untouched. The parsed-capture **cache version is bumped** so existing caches re-parse.

### 2. `filter_pid`
Add an index-backed PID filter to `query_events` and `export_query_results`, so a client can target one process by PID and bypass name-encoding entirely. (There was no PID filter before — isolating a process required its exact name.)

## Verified on the real capture
The malware sample now reads as `温度スイッチ.exe` in the process list and events; `filter_pid=1112` returns its events; and `summarize_operations_by_process("温度スイッチ.exe")` now matches by the repaired name (RegOpenKey 349, RegQueryValue 157, CreateFile 111…).

## Tests
`TestRepairMojibake`, `TestMojibakeParsing` (parser repairs names + paths on load), `TestFilterByPid` (isolate/absent/combined). **140 tests pass**, with and without lxml.

Warrants **v0.3.1** (changelog + version bump included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)