### PR TITLE
Reliability/efficiency/stability hardening (closes #23–#30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-06-23
+
+Reliability/efficiency/stability hardening pass (code review).
+
+### Fixed
+- **A mid-stream parse error no longer reports success or caches a truncated
+  capture.** `load_procmon_xml` now raises on incomplete consumption and skips
+  the cache write, instead of returning partial events and persisting them. (#23)
+- **stdlib (no-lxml) error handling:** the parser caught `ET_impl.XMLSyntaxError`,
+  which does not exist on `xml.etree.ElementTree` (it has `ParseError`) — on
+  malformed XML this raised `AttributeError` and masked the real error. A
+  backend-correct `compat.XMLSyntaxError` alias is now used.
+
+### Changed
+- **Loading runs off the event loop** (`asyncio.to_thread`), so the server stays
+  responsive during a long parse on the HTTP/SSE transports. (#24)
+- **Parsed-capture cache is size-bounded** with LRU eviction (default 5 GiB,
+  override via `PROCMONMCP_CACHE_MAX_BYTES`); cache hits refresh recency. (#25)
+- **`export_query_results` streams rows to disk** instead of buffering every
+  matching event in memory, so exports are bounded-memory on large captures. (#26)
+- **User filter regexes use Google RE2 when available** (linear-time, ReDoS-safe),
+  falling back to stdlib `re` with the existing length cap. Install via the
+  optional `re2` extra. (#27)
+- **`find_file_access`** lazily heap-merges per-path index lists and stops at
+  `limit` instead of collecting and sorting every match. (#28)
+- Hot scan loops read the wall clock only periodically (`CLOCK_CHECK_INTERVAL`)
+  rather than every event. (#29)
+- Event-detail formatting uses a shallow `ProcessInfo.to_dict()` instead of
+  `dataclasses.asdict()` (no deep recursion per row). (#30)
+- Minor: factored the duplicated HTTP transport-settings block in the CLI;
+  pre-intern `Process Start`.
+
 ## [0.3.1] - 2026-06-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ pip install -e ".[dev]"  # editable install with test tooling
 | `mcp[cli]>=1.8.0` | Yes | MCP SDK with CLI tools and Streamable HTTP support |
 | `lxml>=4.9.0` | Recommended | Faster XML parsing (falls back to stdlib `ElementTree` if absent) |
 | `psutil>=5.9.0` | Optional | Memory usage reporting after file loading |
+| `google-re2` | Optional | Linear-time, ReDoS-safe engine for user filter regexes (`pip install ".[re2]"`; falls back to stdlib `re`) |
 
 Install all at once:
 ```bash
@@ -254,7 +255,9 @@ under a second.
   cached separately.
 - Bypass it with `--no-cache` (CLI) or `no_cache: true` (the `load_file` tool); the
   `from_cache` field in the load response indicates whether the cache was used.
-- Clear it with `--clear-cache` (CLI) or the `clear_cache` tool.
+- Clear it with `--clear-cache` (CLI) or the `clear_cache` tool. The cache is
+  size-bounded with LRU eviction (default 5 GiB; override with the
+  `PROCMONMCP_CACHE_MAX_BYTES` environment variable).
 - **Security:** cache files are serialized with Python's `pickle` and are read back only
   from your user-owned `~/.procmonmcp/cache` directory (only this tool's own output is
   ever deserialized). Do not point the cache at a location other users can write to.

--- a/procmon_mcp/cache.py
+++ b/procmon_mcp/cache.py
@@ -38,6 +38,17 @@ CACHE_VERSION = 2
 CACHE_DIR = os.path.join(os.path.expanduser("~"), ".procmonmcp", "cache")
 
 
+def _cache_max_bytes() -> int:
+    """Total cache-directory budget in bytes (env-overridable; 0 disables eviction)."""
+    raw = os.environ.get("PROCMONMCP_CACHE_MAX_BYTES")
+    if raw is not None:
+        try:
+            return max(0, int(raw))
+        except ValueError:
+            logger.warning(f"cache: invalid PROCMONMCP_CACHE_MAX_BYTES={raw!r}; using default.")
+    return 5 * 1024 ** 3  # 5 GiB default
+
+
 def compute_key(filename_abs: str, load_stack: bool, load_extra: bool) -> Optional[Dict[str, Any]]:
     """Builds the cache key (file identity + load options + version), or None.
 
@@ -76,8 +87,10 @@ def load(key: Optional[Dict[str, Any]]) -> Optional[ProcmonLogData]:
     except Exception as e:
         logger.warning(f"cache: failed to read '{path}': {e}; ignoring.")
         return None
-    # Validate the embedded header against the requested key (defense in depth
-    # against hash collisions or a stale/incompatible entry).
+    # Validate the embedded header against the requested key — guards against a
+    # stale/incompatible entry or a (vanishingly unlikely) hash collision. This
+    # is NOT a security control: pickle.load above already runs any embedded code,
+    # so the only safeguard against malicious pickles is the user-owned cache dir.
     if not isinstance(payload, dict) or payload.get("header") != key:
         logger.warning(f"cache: header mismatch in '{path}'; ignoring.")
         return None
@@ -85,8 +98,48 @@ def load(key: Optional[Dict[str, Any]]) -> Optional[ProcmonLogData]:
     if not isinstance(data, ProcmonLogData) or not data.is_loaded():
         logger.warning(f"cache: invalid payload in '{path}'; ignoring.")
         return None
+    # Refresh recency so least-recently-used entries are evicted first.
+    try:
+        os.utime(path, None)
+    except OSError:
+        pass
     data.loaded_from_cache = True
     return data
+
+
+def _enforce_cache_limit() -> None:
+    """Evict least-recently-used cache files until the dir is within budget."""
+    cap = _cache_max_bytes()
+    if cap <= 0:
+        return
+    try:
+        entries = []
+        total = 0
+        for name in os.listdir(CACHE_DIR):
+            if not name.endswith(".pkl"):
+                continue
+            fpath = os.path.join(CACHE_DIR, name)
+            try:
+                st = os.stat(fpath)
+            except OSError:
+                continue
+            entries.append((st.st_mtime, st.st_size, fpath))
+            total += st.st_size
+        if total <= cap:
+            return
+        # Remove oldest first until within budget.
+        entries.sort()  # by mtime ascending (least recently used first)
+        for _mtime, size, fpath in entries:
+            if total <= cap:
+                break
+            try:
+                os.remove(fpath)
+                total -= size
+                logger.info(f"cache: evicted '{os.path.basename(fpath)}' to stay within budget.")
+            except OSError as e:
+                logger.warning(f"cache: could not evict '{fpath}': {e}")
+    except OSError as e:
+        logger.warning(f"cache: could not enforce size limit on '{CACHE_DIR}': {e}")
 
 
 def save(key: Optional[Dict[str, Any]], log_data: ProcmonLogData) -> bool:
@@ -107,6 +160,7 @@ def save(key: Optional[Dict[str, Any]], log_data: ProcmonLogData) -> bool:
         with open(tmp, "wb") as f:
             pickle.dump({"header": key, "data": log_data}, f, protocol=pickle.HIGHEST_PROTOCOL)
         os.replace(tmp, path)
+        _enforce_cache_limit()
         return True
     except Exception as e:
         logger.warning(f"cache: failed to write '{path}': {e}")

--- a/procmon_mcp/cli.py
+++ b/procmon_mcp/cli.py
@@ -19,6 +19,23 @@ from . import tools  # noqa: F401 - force tool registration
 logger = logging.getLogger(__name__)
 
 
+def _configure_http_settings(args, label):
+    """Applies host/port/log-level to mcp.settings for the HTTP-style transports.
+
+    The MCP SDK's run() takes (transport, mount_path); host and port live on
+    mcp.settings, so both the SSE and Streamable HTTP paths configure them here.
+    """
+    if hasattr(server.mcp, 'settings'):
+        logger.info(f"Configuring MCP for {label}...")
+        server.mcp.settings.host = args.mcp_host
+        server.mcp.settings.port = args.mcp_port
+        log_level = logging.DEBUG if args.debug else logging.INFO
+        server.mcp.settings.log_level = logging.getLevelName(log_level).lower()
+        logger.info(f"  MCP Host: {server.mcp.settings.host}, Port: {server.mcp.settings.port}")
+    else:
+        logger.warning(f"MCP object lacks 'settings'; cannot configure {label} via arguments.")
+
+
 def main_execution(args):
     """Encapsulates the main loading and server run logic for profiling."""
     load_stacks = not args.no_stack_traces
@@ -92,31 +109,13 @@ def main_execution(args):
                 DeprecationWarning,
                 stacklevel=1,
             )
-            if hasattr(server.mcp, 'settings'):
-                logger.info("Configuring MCP for SSE transport (deprecated)...")
-                server.mcp.settings.host = args.mcp_host
-                server.mcp.settings.port = args.mcp_port
-                log_level = logging.DEBUG if args.debug else logging.INFO
-                mcp_log_level_name = logging.getLevelName(log_level)
-                server.mcp.settings.log_level = mcp_log_level_name.lower()
-                logger.info(f"  MCP Host: {server.mcp.settings.host}, Port: {server.mcp.settings.port}")
-            else:
-                logger.warning("MCP object lacks 'settings'; cannot configure SSE via arguments.")
+            _configure_http_settings(args, "SSE transport (deprecated)")
             logger.info(f"Starting MCP server with SSE transport on http://{args.mcp_host}:{args.mcp_port}")
             server.mcp.run(transport="sse")
             server_started = True
 
         elif transport == "streamable-http":
-            if hasattr(server.mcp, 'settings'):
-                logger.info("Configuring MCP for Streamable HTTP transport...")
-                server.mcp.settings.host = args.mcp_host
-                server.mcp.settings.port = args.mcp_port
-                log_level = logging.DEBUG if args.debug else logging.INFO
-                mcp_log_level_name = logging.getLevelName(log_level)
-                server.mcp.settings.log_level = mcp_log_level_name.lower()
-                logger.info(f"  MCP Host: {server.mcp.settings.host}, Port: {server.mcp.settings.port}")
-            else:
-                logger.warning("MCP object lacks 'settings'; cannot configure Streamable HTTP via arguments.")
+            _configure_http_settings(args, "Streamable HTTP transport")
             logger.info(f"Starting MCP server with Streamable HTTP transport on "
                         f"http://{args.mcp_host}:{args.mcp_port}/mcp")
             server.mcp.run(transport="streamable-http")

--- a/procmon_mcp/compat.py
+++ b/procmon_mcp/compat.py
@@ -20,8 +20,13 @@ LXML_AVAILABLE = False
 try:
     from lxml import etree as ET_impl
     LXML_AVAILABLE = True
+    # lxml raises XMLSyntaxError on malformed XML.
+    XMLSyntaxError = ET_impl.XMLSyntaxError
 except ImportError:
     import xml.etree.ElementTree as ET_impl
+    # The stdlib ElementTree has no XMLSyntaxError; it raises ParseError. Alias it
+    # so callers can `except XMLSyntaxError` regardless of which backend is active.
+    XMLSyntaxError = ET_impl.ParseError
 
 # --- Memory Usage Reporting ---
 PSUTIL_AVAILABLE = False

--- a/procmon_mcp/constants.py
+++ b/procmon_mcp/constants.py
@@ -10,6 +10,9 @@ PROCMON_TIMESTAMP_FORMAT = "%H:%M:%S.%f"
 # Progress reporting thresholds
 PROGRESS_REPORT_INTERVAL = 250000  # Report progress every N events during loading/processing
 PROGRESS_REPORT_SECONDS = 5.0  # Also report progress every N seconds
+# Only read the wall clock once per this many iterations in hot scan loops, so
+# the time-based progress fallback doesn't cost a syscall on every event.
+CLOCK_CHECK_INTERVAL = 8192
 
 # Base date (epoch) for creating full timestamps from Time_of_Day.
 # The parser will advance this date if it detects a midnight rollover.

--- a/procmon_mcp/filters.py
+++ b/procmon_mcp/filters.py
@@ -1,13 +1,14 @@
 """Event filtering engine for ProcmonMCP."""
 import re
 import time
+import asyncio
 import logging
 from datetime import datetime, timezone
 from typing import Optional, Any, Tuple, Set, AsyncIterator
 
 from .compat import Context
 from .constants import (
-    PROCMON_TIMESTAMP_FORMAT, PROGRESS_REPORT_INTERVAL, PROGRESS_REPORT_SECONDS,
+    PROCMON_TIMESTAMP_FORMAT, PROGRESS_REPORT_SECONDS, CLOCK_CHECK_INTERVAL,
     MAX_FILTER_STR_LEN,
     IK_PROCESS_NAME, IK_OPERATION, IK_PATH, IK_RESULT, IK_STACK_PATH,
 )
@@ -180,19 +181,24 @@ async def _iter_filtered_event_indices(
         last_progress_report_time = start_time
 
         # Main filtering loop
+        report_interval = max(10000, total_to_scan // 20) if total_to_scan > 0 else 10000
         for idx in indices_to_check:
             event_dict = log_data.events[idx]
             processed_count += 1
 
-            # Progress reporting
-            current_time = time.time()
-            report_interval = max(10000, total_to_scan // 20) if total_to_scan > 0 else 10000
-            if processed_count % report_interval == 0 or (current_time - last_progress_report_time > PROGRESS_REPORT_SECONDS):
-                try:
-                    await ctx.info(f" Filter scanned {processed_count:,}/{total_to_scan:,} candidate events... ({current_time - start_time:.1f}s)")
-                except Exception as progress_err:
-                    logger.warning(f"Failed to send progress update during filter: {progress_err}")
-                last_progress_report_time = current_time
+            # Progress reporting. Only read the wall clock periodically (not every
+            # event), and yield to the event loop so a long scan on an HTTP
+            # transport doesn't starve other requests.
+            if processed_count % CLOCK_CHECK_INTERVAL == 0:
+                current_time = time.time()
+                if processed_count % report_interval == 0 or (current_time - last_progress_report_time > PROGRESS_REPORT_SECONDS):
+                    try:
+                        await ctx.info(f" Filter scanned {processed_count:,}/{total_to_scan:,} candidate events... ({current_time - start_time:.1f}s)")
+                    except Exception as progress_err:
+                        logger.warning(f"Failed to send progress update during filter: {progress_err}")
+                    last_progress_report_time = current_time
+                else:
+                    await asyncio.sleep(0)
 
             # Apply filters sequentially (fail fast)
             if not index_used:

--- a/procmon_mcp/formatters.py
+++ b/procmon_mcp/formatters.py
@@ -1,5 +1,4 @@
 """Event detail formatting for ProcmonMCP."""
-import dataclasses
 import logging
 from datetime import datetime, timezone
 from typing import Dict, Any, Optional
@@ -77,7 +76,7 @@ def _get_formatted_event_details(log_data: ProcmonLogData, event_index: int) -> 
         # Enriched process info
         process_obj = log_data.processes_by_pid.get(details.get('pid')) if details.get('pid') is not None else None
         if process_obj:
-            proc_details_dict = dataclasses.asdict(process_obj)
+            proc_details_dict = process_obj.to_dict()
             proc_details_dict.pop('process_index', None)
             proc_details_dict.pop('parent_process_index', None)
             details['process_details_summary'] = proc_details_dict

--- a/procmon_mcp/helpers.py
+++ b/procmon_mcp/helpers.py
@@ -10,16 +10,38 @@ from .constants import PROCMON_TIMESTAMP_FORMAT, BASE_DATE, MAX_REGEX_LEN
 
 logger = logging.getLogger(__name__)
 
+# Prefer Google RE2 (linear-time, immune to catastrophic backtracking) for
+# user-supplied filter regexes when available, so a pathological pattern can't
+# hang the server (ReDoS). Falls back to the stdlib `re` (length-capped) when
+# RE2 is not installed or cannot compile the pattern.
+try:
+    import re2 as _re2  # provided by the optional `google-re2` package
+    RE2_AVAILABLE = True
+except ImportError:
+    _re2 = None
+    RE2_AVAILABLE = False
+
 
 # --- Safe Regex Helper ---
-def _compile_safe_regex(pattern: Optional[str], name: str) -> Optional[re.Pattern]:
-    """Compile a regex pattern with length validation to mitigate ReDoS."""
+def _compile_safe_regex(pattern: Optional[str], name: str):
+    """Compile a user regex with ReDoS mitigation.
+
+    Enforces a maximum pattern length, then compiles with RE2 (linear-time) when
+    available. RE2 rejects a few constructs (back-references, look-around); on
+    such a pattern we fall back to stdlib `re` (still length-capped). Raises
+    ValueError on over-length patterns and re.error on invalid patterns.
+    """
     if pattern is None:
         return None
     if len(pattern) > MAX_REGEX_LEN:
         raise ValueError(
             f"Regex pattern for '{name}' exceeds maximum length of {MAX_REGEX_LEN} characters."
         )
+    if RE2_AVAILABLE:
+        try:
+            return _re2.compile(pattern, _re2.IGNORECASE)
+        except Exception as e:
+            logger.info(f"RE2 could not compile filter '{name}' ({e}); falling back to stdlib re.")
     return re.compile(pattern, re.IGNORECASE)
 
 

--- a/procmon_mcp/models.py
+++ b/procmon_mcp/models.py
@@ -112,6 +112,15 @@ class ProcessInfo:
     def user_sid(self):
         return self.owner
 
+    def to_dict(self) -> Dict[str, Any]:
+        """Shallow dict of the dataclass fields.
+
+        Equivalent to dataclasses.asdict() here (all fields are scalars) but
+        avoids asdict's deep recursion/copy — meaningful when called per event
+        during large exports.
+        """
+        return {f.name: getattr(self, f.name) for f in dataclasses.fields(self)}
+
     @staticmethod
     def _safe_text_to_int(text: Optional[str]) -> Optional[int]:
         """Safely converts text (decimal or hex '0x...') to int, returning None on failure."""

--- a/procmon_mcp/parser.py
+++ b/procmon_mcp/parser.py
@@ -10,11 +10,12 @@ import contextlib
 from datetime import datetime, timezone, timedelta, time as dt_time
 from typing import Dict, Any, Optional, Iterator, IO
 
-from .compat import ET_impl, LXML_AVAILABLE
+from .compat import ET_impl, LXML_AVAILABLE, XMLSyntaxError
 from .constants import (
     PROCMON_TIMESTAMP_FORMAT, PROGRESS_REPORT_INTERVAL, PROGRESS_REPORT_SECONDS,
+    CLOCK_CHECK_INTERVAL,
     BASE_DATE, ROLLOVER_THRESHOLD_SECONDS,
-    OP_PROCESS_CREATE, OP_PROCESS_EXIT, NETWORK_OPERATIONS,
+    OP_PROCESS_CREATE, OP_PROCESS_START, OP_PROCESS_EXIT, NETWORK_OPERATIONS,
     IK_PROCESS_NAME, IK_OPERATION, IK_PATH, IK_RESULT, IK_CATEGORY,
     IK_STACK_PATH, IK_STACK_LOCATION,
 )
@@ -94,7 +95,7 @@ def _parse_xml_processes_only(source_stream: IO[bytes]) -> Dict[int, ProcessInfo
                 logger.warning("Reached end of <procmon> while parsing processes.")
                 break
 
-    except ET_impl.XMLSyntaxError as e:
+    except XMLSyntaxError as e:
         logger.error(f"XML Parse Error during process parsing: {e}")
         raise
     except Exception as e:
@@ -302,21 +303,23 @@ def _parse_xml_stream_for_loading(
                         yield opt_event
                         yielded_count += 1
 
-                        # Progress reporting
-                        current_time = time.time()
-                        if yielded_count % PROGRESS_REPORT_INTERVAL == 0 or (current_time - last_report_time) > PROGRESS_REPORT_SECONDS:
-                            elapsed_total = current_time - start_time
-                            rate = yielded_count / elapsed_total if elapsed_total > 0 else 0
-                            percent_str = ""
-                            if raw_file_stream and total_size is not None and total_size > 0:
-                                try:
-                                    current_pos = raw_file_stream.tell()
-                                    percent = (current_pos / total_size) * 100
-                                    percent_str = f" ({percent:.1f}%)"
-                                except (OSError, AttributeError, TypeError, io.UnsupportedOperation) as tell_err:
-                                    logger.debug(f"Could not get raw stream position for progress: {tell_err}")
-                            logger.info(f"  [Pass 2] Yielded {yielded_count:,} events{percent_str}... ({elapsed_total:.1f}s | {rate:,.0f} events/sec)")
-                            last_report_time = current_time
+                        # Progress reporting. Only read the wall clock periodically
+                        # (not every event) to keep the hot path cheap.
+                        if yielded_count % CLOCK_CHECK_INTERVAL == 0:
+                            current_time = time.time()
+                            if yielded_count % PROGRESS_REPORT_INTERVAL == 0 or (current_time - last_report_time) > PROGRESS_REPORT_SECONDS:
+                                elapsed_total = current_time - start_time
+                                rate = yielded_count / elapsed_total if elapsed_total > 0 else 0
+                                percent_str = ""
+                                if raw_file_stream and total_size is not None and total_size > 0:
+                                    try:
+                                        current_pos = raw_file_stream.tell()
+                                        percent = (current_pos / total_size) * 100
+                                        percent_str = f" ({percent:.1f}%)"
+                                    except (OSError, AttributeError, TypeError, io.UnsupportedOperation) as tell_err:
+                                        logger.debug(f"Could not get raw stream position for progress: {tell_err}")
+                                logger.info(f"  [Pass 2] Yielded {yielded_count:,} events{percent_str}... ({elapsed_total:.1f}s | {rate:,.0f} events/sec)")
+                                last_report_time = current_time
 
                     except Exception as event_parse_err:
                         logger.warning(f"Error parsing event #{event_count}: {event_parse_err}", exc_info=True)
@@ -330,7 +333,7 @@ def _parse_xml_stream_for_loading(
         elapsed = time.time() - start_time
         logger.info(f"Finished Pass 2: Processed {event_count:,} <event> elements, yielded {yielded_count:,}, skipped {skipped_count:,} ({elapsed:.2f}s).")
 
-    except ET_impl.XMLSyntaxError as e:
+    except XMLSyntaxError as e:
         logger.error(f"XML Parse Error during event loading stream: {e}")
         raise
     except Exception as e:
@@ -411,6 +414,7 @@ def load_procmon_xml(filename_abs: str, load_stack: bool, load_extra: bool,
     }
     # Pre-intern known operation strings
     log_data.interners[IK_OPERATION].get_id(OP_PROCESS_CREATE)
+    log_data.interners[IK_OPERATION].get_id(OP_PROCESS_START)
     log_data.interners[IK_OPERATION].get_id(OP_PROCESS_EXIT)
     for op in NETWORK_OPERATIONS:
         log_data.interners[IK_OPERATION].get_id(op)
@@ -456,6 +460,7 @@ def load_procmon_xml(filename_abs: str, load_stack: bool, load_extra: bool,
                 logger.info("[Loader] Starting consumption of event iterator and building indices...")
                 temp_event_list = []
                 consumed_count = 0
+                consumption_error: Optional[Exception] = None
                 indexing_start_time = time.time()
                 try:
                     for idx, opt_event in enumerate(event_iterator):
@@ -476,6 +481,7 @@ def load_procmon_xml(filename_abs: str, load_stack: bool, load_extra: bool,
                             log_data.path_id_index[path_id].append(idx)
 
                 except Exception as consume_err:
+                    consumption_error = consume_err
                     logger.error(f"[Loader] Error during iterator consumption/indexing after {consumed_count} events: {consume_err}", exc_info=True)
                 finally:
                     logger.info(f"[Loader] Finished consuming event iterator. Total events consumed: {consumed_count}. Final list length: {len(temp_event_list)}. Indexing time: {time.time() - indexing_start_time:.2f}s")
@@ -485,6 +491,14 @@ def load_procmon_xml(filename_abs: str, load_stack: bool, load_extra: bool,
         finally:
             if raw_f:
                 raw_f.close()
+
+        # A mid-stream parse error means the capture is only partially loaded.
+        # Fail loudly instead of returning a silently-truncated result — and,
+        # critically, do NOT cache the partial data below.
+        if consumption_error is not None:
+            raise RuntimeError(
+                f"Parsing failed after {consumed_count:,} events (capture is incomplete): {consumption_error}"
+            ) from consumption_error
 
         # Final Summary
         overall_end_time = time.time()
@@ -507,7 +521,7 @@ def load_procmon_xml(filename_abs: str, load_stack: bool, load_extra: bool,
     except (FileNotFoundError, ValueError) as e:
         logger.error(f"File error: {e}")
         raise
-    except ET_impl.XMLSyntaxError as e:
+    except XMLSyntaxError as e:
         logger.error(f"XML Syntax Error in {filename_abs}: {e}")
         raise RuntimeError(f"Invalid XML: {e}") from e
     except OSError as e:

--- a/procmon_mcp/tools.py
+++ b/procmon_mcp/tools.py
@@ -4,8 +4,9 @@ import os
 import csv
 import json
 import time
+import heapq
+import asyncio
 import logging
-import dataclasses
 from collections import defaultdict
 from datetime import datetime, timezone
 from typing import List, Dict, Any, Optional
@@ -13,6 +14,7 @@ from typing import List, Dict, Any, Optional
 from .compat import Context, PSUTIL_AVAILABLE
 from .constants import (
     PROCMON_TIMESTAMP_FORMAT, PROGRESS_REPORT_INTERVAL, PROGRESS_REPORT_SECONDS,
+    CLOCK_CHECK_INTERVAL,
     OP_PROCESS_EXIT, PROCESS_CREATE_OPERATIONS, NETWORK_OPERATIONS,
     IK_PROCESS_NAME, IK_OPERATION, IK_PATH, IK_RESULT, IK_CATEGORY,
     IK_STACK_PATH, IK_STACK_LOCATION,
@@ -24,6 +26,16 @@ from .formatters import _get_formatted_event_details
 from .helpers import _format_bytes, parse_network_endpoint_parts, network_direction
 
 logger = logging.getLogger(__name__)
+
+# Canonical column order for CSV export. Mirrors the keys produced by
+# _get_formatted_event_details so rows can be streamed without first collecting
+# every event to discover the header.
+_EXPORT_FIELDNAMES = [
+    'event_index', 'sequence_number', 'timestamp', 'timestamp_unix', 'process_name',
+    'pid', 'tid', 'parent_pid', 'operation', 'path', 'result', 'detail', 'duration',
+    'category', 'extra_data', 'stack_trace', 'user_sid', 'is_64bit_process',
+    'process_details_summary', 'completion_time', 'relative_time',
+]
 
 
 # ---- Lifecycle tools (load_file, get_status) ----
@@ -138,7 +150,11 @@ async def load_file(
                        f"(stacks={'yes' if load_stacks else 'no'}, extra={'yes' if load_extra else 'no'})...")
 
         start_time = time.time()
-        new_data = load_procmon_xml(abs_path, load_stacks, load_extra, use_cache=not no_cache)
+        # Parsing is CPU-bound and synchronous; run it off the event loop so the
+        # server stays responsive (e.g. to get_status) during a long load.
+        new_data = await asyncio.to_thread(
+            load_procmon_xml, abs_path, load_stacks, load_extra, use_cache=not no_cache
+        )
 
         if not new_data or not new_data.is_loaded():
             await ctx.error("[load_file] File loading failed. Check server logs for details.")
@@ -510,7 +526,7 @@ async def get_process_details(pid: int, ctx: Context) -> Dict[str, Any]:
             await ctx.error(f"[get_process_details] PID {pid} not found in process list.")
             raise ValueError(f"Process with PID {pid} not found in pre-loaded list.")
 
-        details = dataclasses.asdict(process_obj)
+        details = process_obj.to_dict()
         details.pop('process_index', None)
         details.pop('parent_process_index', None)
         details['modules_summary'] = "N/A (Module info not typically in XML process list)"
@@ -616,14 +632,15 @@ async def summarize_operations_by_process(process_name_filter: str, ctx: Context
         last_progress_report_time = start_time
 
         for i, idx in enumerate(indices_to_check):
-            current_time = time.time()
-            if i > 0 and (i % (PROGRESS_REPORT_INTERVAL * 4) == 0 or (current_time - last_progress_report_time > PROGRESS_REPORT_SECONDS)):
-                elapsed = current_time - start_time
-                try:
-                    await ctx.info(f"[summarize_operations_by_process] Processed {i:,}/{len(indices_to_check):,} events ({elapsed:.1f}s)")
-                except Exception as progress_err:
-                    logger.warning(f"Failed to send progress update during summarize: {progress_err}")
-                last_progress_report_time = current_time
+            if i > 0 and i % CLOCK_CHECK_INTERVAL == 0:
+                current_time = time.time()
+                if i % (PROGRESS_REPORT_INTERVAL * 4) == 0 or (current_time - last_progress_report_time > PROGRESS_REPORT_SECONDS):
+                    elapsed = current_time - start_time
+                    try:
+                        await ctx.info(f"[summarize_operations_by_process] Processed {i:,}/{len(indices_to_check):,} events ({elapsed:.1f}s)")
+                    except Exception as progress_err:
+                        logger.warning(f"Failed to send progress update during summarize: {progress_err}")
+                    last_progress_report_time = current_time
 
             event_dict = log_data.events[idx]
             event_count_for_process += 1
@@ -665,14 +682,15 @@ async def get_timing_statistics(group_by: str = "process", *, ctx: Context) -> D
         last_progress_report_time = start_time
 
         for i, event_dict in enumerate(log_data.events):
-            current_time = time.time()
-            if i > 0 and (i % (PROGRESS_REPORT_INTERVAL * 4) == 0 or (current_time - last_progress_report_time > PROGRESS_REPORT_SECONDS)):
-                elapsed = current_time - start_time
-                try:
-                    await ctx.info(f"[get_timing_statistics] Processed {i:,}/{total_events:,} events ({elapsed:.1f}s)")
-                except Exception as progress_err:
-                    logger.warning(f"Failed to send progress update during timing stats: {progress_err}")
-                last_progress_report_time = current_time
+            if i > 0 and i % CLOCK_CHECK_INTERVAL == 0:
+                current_time = time.time()
+                if i % (PROGRESS_REPORT_INTERVAL * 4) == 0 or (current_time - last_progress_report_time > PROGRESS_REPORT_SECONDS):
+                    elapsed = current_time - start_time
+                    try:
+                        await ctx.info(f"[get_timing_statistics] Processed {i:,}/{total_events:,} events ({elapsed:.1f}s)")
+                    except Exception as progress_err:
+                        logger.warning(f"Failed to send progress update during timing stats: {progress_err}")
+                    last_progress_report_time = current_time
 
             duration = event_dict.get('dur')
             if duration is None or not isinstance(duration, (float, int)) or duration <= 0:
@@ -808,15 +826,11 @@ async def find_file_access(path_contains: str, limit: int = 100, *, ctx: Context
 
     await ctx.info(f"[find_file_access] Found {len(matching_path_ids)} matching unique paths out of {len(log_data.path_id_index)}.")
 
-    # Phase 2: Collect events from matching paths, sorted by event index
-    # Merge-sort approach: collect all candidate indices, sort, then take up to limit
-    candidate_indices = []
-    for _, _, event_indices in matching_path_ids:
-        candidate_indices.extend(event_indices)
-    candidate_indices.sort()
-
-    # Phase 3: Build summaries up to limit
-    for idx in candidate_indices:
+    # Phase 2 + 3: Lazily merge the per-path index lists (already sorted ascending,
+    # and disjoint since each event has one path) and stop after `limit`. Avoids
+    # materializing and sorting every matching index when the substring is broad.
+    merged = heapq.merge(*(event_indices for _, _, event_indices in matching_path_ids))
+    for idx in merged:
         if count >= limit:
             break
         event_dict = log_data.events[idx]
@@ -1037,12 +1051,20 @@ async def export_query_results(
     if not log_data.events:
         await ctx.info("[export_query_results] Completed. No events loaded to export.")
         return {"success": True, "output_path": abs_output_path, "events_exported": 0}
-    events_to_export = []
     events_exported = 0
+    indices_processed = 0
     export_start_time = time.time()
+    fmt = output_format.lower()
+
+    async def _progress():
+        if indices_processed % 10000 == 0:
+            try:
+                await ctx.info(f"[export_query_results] Streamed {indices_processed:,} events...")
+            except Exception:
+                pass
 
     try:
-        await ctx.info("[export_query_results] Filtering events...")
+        await ctx.info("[export_query_results] Filtering and streaming events to file...")
         event_indices_iterator = _iter_filtered_event_indices(
             log_data=log_data, ctx=ctx,
             filter_process=filter_process, filter_pid=filter_pid, filter_operation=filter_operation,
@@ -1053,70 +1075,50 @@ async def export_query_results(
             filter_stack_module_path=filter_stack_module_path
         )
 
-        await ctx.info("Retrieving full details for matching events...")
-        detail_retrieval_start = time.time()
-        indices_processed = 0
-        async for event_idx in event_indices_iterator:
-            indices_processed += 1
-            details = _get_formatted_event_details(log_data, event_idx)
-            if details:
-                events_to_export.append(details)
-            else:
-                await ctx.warning(f"[export_query_results] Could not retrieve details for event index {event_idx}, skipping.")
-
-            if indices_processed % 10000 == 0:
-                try:
-                    await ctx.info(f"[export_query_results] Retrieved details for {indices_processed:,} events...")
-                except Exception:
-                    pass
-
-        await ctx.info(f"[export_query_results] Retrieved {len(events_to_export)} event details in {time.time() - detail_retrieval_start:.2f}s.")
-
-        if not events_to_export:
-            await ctx.info("[export_query_results] No matching events to export.")
-            if output_format.lower() == 'csv':
-                try:
-                    with open(abs_output_path, 'w', newline='', encoding='utf-8') as csvfile:
-                        fieldnames = ['event_index', 'sequence_number', 'timestamp', 'process_name', 'pid', 'tid', 'operation', 'path', 'result', 'detail', 'duration', 'category', 'parent_pid', 'extra_data', 'stack_trace', 'user_sid', 'is_64bit_process', 'process_details_summary']
-                        writer = csv.DictWriter(csvfile, fieldnames=fieldnames, extrasaction='ignore')
-                        writer.writeheader()
-                    await ctx.info(f"Created empty CSV file with headers: {abs_output_path}")
-                except IOError as e:
-                    await ctx.error(f"Error writing empty CSV file '{abs_output_path}': {e}")
-            return {"success": True, "output_path": abs_output_path, "events_exported": 0}
-
-        if output_format.lower() == 'csv':
-            fieldnames = list(events_to_export[0].keys())
-            try:
-                with open(abs_output_path, 'w', newline='', encoding='utf-8') as csvfile:
-                    writer = csv.DictWriter(csvfile, fieldnames=fieldnames, extrasaction='ignore')
-                    writer.writeheader()
-                    for row_dict in events_to_export:
-                        csv_row = dict(row_dict)
-                        if isinstance(csv_row.get('extra_data'), dict):
-                            csv_row['extra_data'] = json.dumps(csv_row['extra_data'])
-                        if isinstance(csv_row.get('stack_trace'), list):
-                            csv_row['stack_trace'] = json.dumps(csv_row['stack_trace'])
-                        if isinstance(csv_row.get('process_details_summary'), dict):
-                            csv_row['process_details_summary'] = json.dumps(csv_row['process_details_summary'])
-                        writer.writerow(csv_row)
-                        events_exported += 1
-            except IOError as e:
-                await ctx.error(f"Error writing CSV file '{abs_output_path}': {e}")
-                raise RuntimeError(f"Failed to write CSV file: {e}") from e
-        elif output_format.lower() == 'json':
-            try:
-                with open(abs_output_path, 'w', encoding='utf-8') as jsonfile:
-                    json.dump(events_to_export, jsonfile, indent=2)
-                    events_exported = len(events_to_export)
-            except IOError as e:
-                await ctx.error(f"Error writing JSON file '{abs_output_path}': {e}")
-                raise RuntimeError(f"Failed to write JSON file: {e}") from e
+        # Stream each matching event straight to disk so memory stays bounded
+        # regardless of how many events match.
+        if fmt == 'csv':
+            with open(abs_output_path, 'w', newline='', encoding='utf-8') as csvfile:
+                writer = csv.DictWriter(csvfile, fieldnames=_EXPORT_FIELDNAMES, extrasaction='ignore')
+                writer.writeheader()
+                async for event_idx in event_indices_iterator:
+                    indices_processed += 1
+                    details = _get_formatted_event_details(log_data, event_idx)
+                    if not details:
+                        await ctx.warning(f"[export_query_results] Could not retrieve details for event index {event_idx}, skipping.")
+                        continue
+                    row = dict(details)
+                    for key in ('extra_data', 'stack_trace', 'process_details_summary'):
+                        if isinstance(row.get(key), (dict, list)):
+                            row[key] = json.dumps(row[key])
+                    writer.writerow(row)
+                    events_exported += 1
+                    await _progress()
+        else:  # json — write a streamed array
+            with open(abs_output_path, 'w', encoding='utf-8') as jsonfile:
+                jsonfile.write('[')
+                first = True
+                async for event_idx in event_indices_iterator:
+                    indices_processed += 1
+                    details = _get_formatted_event_details(log_data, event_idx)
+                    if not details:
+                        await ctx.warning(f"[export_query_results] Could not retrieve details for event index {event_idx}, skipping.")
+                        continue
+                    jsonfile.write('\n' if first else ',\n')
+                    jsonfile.write(json.dumps(details, indent=2))
+                    first = False
+                    events_exported += 1
+                    await _progress()
+                jsonfile.write('\n]' if not first else ']')
 
         export_elapsed = time.time() - export_start_time
-        await ctx.info(f"[export_query_results] Completed. Exported {events_exported} events to '{output_file}' ({output_format}, {export_elapsed:.2f}s).")
+        await ctx.info(f"[export_query_results] Completed. Exported {events_exported} events to '{output_file}' ({fmt}, {export_elapsed:.2f}s).")
         return {"success": True, "output_path": abs_output_path, "events_exported": events_exported}
 
+    except OSError as e:
+        await ctx.error(f"[export_query_results] Error writing '{abs_output_path}': {e}")
+        logger.debug("Exception details:", exc_info=True)
+        raise RuntimeError(f"Failed to write {fmt} file: {e}") from e
     except Exception as e:
         await ctx.error(f"[export_query_results] Failed: {e}")
         logger.debug("Exception details:", exc_info=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "procmon-mcp"
-version = "0.3.1"
+version = "0.4.0"
 description = "Model Context Protocol (MCP) server for analysing Process Monitor (Procmon) XML log files."
 readme = "README.md"
 requires-python = ">=3.7"
@@ -28,6 +28,9 @@ dependencies = [
 lxml = ["lxml>=4.9.0"]
 # Memory-usage reporting after loading (silently skipped if absent).
 psutil = ["psutil>=5.9.0"]
+# Linear-time regex engine for user filter patterns (ReDoS-safe); falls back to
+# stdlib `re` if absent. Not in `all` because it has native build dependencies.
+re2 = ["google-re2"]
 # Everything optional, for convenience.
 all = ["lxml>=4.9.0", "psutil>=5.9.0"]
 # Development/test tooling.

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -232,7 +232,7 @@ class TestCompileSafeRegex:
 
     def test_valid_pattern_compiles(self):
         result = procmon_mcp._compile_safe_regex("foo.*bar", "test")
-        assert isinstance(result, re.Pattern)
+        assert result is not None and hasattr(result, "search")  # re.Pattern or RE2 matcher
 
     def test_case_insensitive(self):
         regex = procmon_mcp._compile_safe_regex("hello", "test")
@@ -246,7 +246,7 @@ class TestCompileSafeRegex:
     def test_at_max_length_ok(self):
         pattern = "a" * procmon_mcp.MAX_REGEX_LEN
         result = procmon_mcp._compile_safe_regex(pattern, "test")
-        assert isinstance(result, re.Pattern)
+        assert result is not None and hasattr(result, "search")  # re.Pattern or RE2 matcher
 
     def test_invalid_regex_raises(self):
         with pytest.raises(re.error):
@@ -1174,3 +1174,124 @@ class TestFilterByPid:
         data = self._load(tmp_path)
         res = _collect_filtered(data, filter_pid=1000, filter_operation="TCP Send")
         assert len(res) == 3  # chrome has 3 TCP Send events
+
+
+# --- Streaming Export Tests ---
+
+class TestExportStreaming:
+    def _load(self, tmp_path, n=5):
+        from procmon_mcp.parser import load_procmon_xml
+        from procmon_mcp import server
+        path = str(tmp_path / "e.xml")
+        _write_capture(path, n, with_stack=True)
+        server.LOADED_DATA = load_procmon_xml(path, True, True)
+        return server.LOADED_DATA
+
+    def _export(self, tmp_path, out, fmt, **filters):
+        from procmon_mcp import tools
+        cwd = os.getcwd()
+        os.chdir(str(tmp_path))
+        try:
+            return _drive(tools.export_query_results(out, fmt, ctx=_DummyContext(), **filters))
+        finally:
+            os.chdir(cwd)
+
+    def test_json_export_valid_and_complete(self, tmp_path):
+        import json as _json
+        self._load(tmp_path, 5)
+        r = self._export(tmp_path, "out.json", "json")
+        assert r["events_exported"] == 5
+        data = _json.loads((tmp_path / "out.json").read_text())
+        assert len(data) == 5 and data[0]["operation"] == "CreateFile"
+
+    def test_csv_export_header_and_rows(self, tmp_path):
+        import csv as _csv
+        self._load(tmp_path, 5)
+        r = self._export(tmp_path, "out.csv", "csv")
+        assert r["events_exported"] == 5
+        with (tmp_path / "out.csv").open() as f:
+            rows = list(_csv.DictReader(f))
+        assert len(rows) == 5 and "process_details_summary" in rows[0]
+
+    def test_empty_json_export_is_empty_array(self, tmp_path):
+        self._load(tmp_path, 3)
+        r = self._export(tmp_path, "empty.json", "json", filter_result="NO SUCH RESULT")
+        assert r["events_exported"] == 0
+        assert (tmp_path / "empty.json").read_text().strip() == "[]"
+
+    def test_empty_csv_export_is_header_only(self, tmp_path):
+        self._load(tmp_path, 3)
+        r = self._export(tmp_path, "empty.csv", "csv", filter_result="NO SUCH RESULT")
+        assert r["events_exported"] == 0
+        lines = (tmp_path / "empty.csv").read_text().strip().splitlines()
+        assert len(lines) == 1 and lines[0].startswith("event_index")
+
+
+# --- find_file_access merge ordering ---
+
+class TestFindFileAccessOrdering:
+    def test_returns_first_indices_ascending(self, tmp_path):
+        from procmon_mcp.parser import load_procmon_xml
+        from procmon_mcp import server, tools
+        path = str(tmp_path / "fa.xml")
+        _write_capture(path, 50, with_stack=False)  # every path contains "System32"
+        server.LOADED_DATA = load_procmon_xml(path, False, False)
+        res = _drive(tools.find_file_access("System32", limit=10, ctx=_DummyContext()))
+        idxs = [e["event_index"] for e in res]
+        assert idxs == list(range(10))  # first 10 by event index, ascending
+
+
+# --- Partial-parse must raise and not cache ---
+
+class TestPartialParseNoCache:
+    def test_truncated_xml_raises_and_does_not_cache(self, tmp_path):
+        from procmon_mcp import cache
+        from procmon_mcp.parser import load_procmon_xml
+        path = tmp_path / "trunc.xml"
+        path.write_text(
+            '<?xml version="1.0" encoding="UTF-8"?>\n<procmon>\n<processlist>\n'
+            '<process><ProcessIndex>0</ProcessIndex><ProcessId>1</ProcessId>'
+            '<ProcessName>t.exe</ProcessName></process>\n</processlist>\n<eventlist>\n'
+            '<event><ProcessIndex>0</ProcessIndex><PID>1</PID>'
+            '<Time_of_Day>12:00:00.000000</Time_of_Day><Operation>CreateFile</Operation>'
+            '<Path>C:\\a</Path><Result>SUCCESS</Result><Process_Name>t.exe</Process_Name></event>\n'
+            '<event><PID>2</PID><Time_of_Day>12:00:01.0000'  # truncated mid-event
+        )
+        with pytest.raises(RuntimeError):
+            load_procmon_xml(str(path), True, True, use_cache=True)
+        cdir = cache.CACHE_DIR
+        pkls = os.listdir(cdir) if os.path.isdir(cdir) else []
+        assert not any(f.endswith(".pkl") for f in pkls)
+
+
+# --- Cache eviction ---
+
+class TestCacheEviction:
+    def test_evicts_lru_when_over_budget(self, tmp_path, monkeypatch):
+        from procmon_mcp import cache
+        from procmon_mcp.models import ProcmonLogData
+        monkeypatch.setattr(cache, "CACHE_DIR", str(tmp_path / "c"))
+        data = ProcmonLogData(loaded_filename="x", events=[{}])
+        base = {"size": 1, "mtime_ns": 1, "load_stack": True,
+                "load_extra": True, "version": cache.CACHE_VERSION}
+        key_a = dict(base, path="a")
+        key_b = dict(base, path="b")
+        assert cache.save(key_a, data)
+        assert cache.save(key_b, data)
+        # Mark A as least-recently-used and cap the dir to ~one entry.
+        os.utime(cache._cache_file(key_a), (1, 1))
+        cap = os.path.getsize(cache._cache_file(key_b)) + 16
+        monkeypatch.setenv("PROCMONMCP_CACHE_MAX_BYTES", str(cap))
+        cache._enforce_cache_limit()
+        names = set(os.listdir(cache.CACHE_DIR))
+        assert os.path.basename(cache._cache_file(key_b)) in names   # newest kept
+        assert os.path.basename(cache._cache_file(key_a)) not in names  # LRU evicted
+
+
+# --- XMLSyntaxError alias (stdlib has ParseError, not XMLSyntaxError) ---
+
+class TestXMLSyntaxErrorAlias:
+    def test_alias_is_real_exception_class(self):
+        from procmon_mcp import compat
+        assert isinstance(compat.XMLSyntaxError, type)
+        assert issubclass(compat.XMLSyntaxError, Exception)


### PR DESCRIPTION
Implements the full-code-review findings. Closes #23, #24, #25, #26, #27, #28, #29, #30 (plus a latent stdlib error-handling bug found along the way).

## Reliability
- **#23** A mid-stream parse error no longer returns partial events as `success` **or caches the truncated capture** — `load_procmon_xml` raises and skips the cache write.
- **(bonus)** The parser caught `ET_impl.XMLSyntaxError`, which doesn't exist on stdlib `ElementTree` (it has `ParseError`) — on malformed XML the no-lxml path raised `AttributeError` and masked the real error. Now uses a backend-correct `compat.XMLSyntaxError` alias.

## Stability
- **#24** `load_file` parses via `asyncio.to_thread`, so the server stays responsive (e.g. to `get_status`) during a long load on HTTP/SSE.
- **#25** Parsed-capture cache is size-bounded with LRU eviction (default 5 GiB, `PROCMONMCP_CACHE_MAX_BYTES` override); cache hits refresh recency.
- **#26** `export_query_results` streams rows to disk — bounded memory regardless of match count.
- **#27** User filter regexes use Google RE2 (linear-time, ReDoS-safe) when the optional `re2` extra is installed; falls back to stdlib `re` with the length cap.

## Efficiency
- **#28** `find_file_access` lazily heap-merges per-path index lists and stops at `limit` (no full collect+sort).
- **#29** Hot scan loops read the wall clock only every `CLOCK_CHECK_INTERVAL` iterations.
- **#30** Event-detail formatting uses a shallow `ProcessInfo.to_dict()` instead of `dataclasses.asdict()` per row.

Polish: factored the duplicated CLI HTTP-settings block; pre-intern `Process Start`.

## Verification
- New tests: `TestExportStreaming`, `TestFindFileAccessOrdering`, `TestPartialParseNoCache`, `TestCacheEviction`, `TestXMLSyntaxErrorAlias`. **148 tests pass**, with and without lxml; SDK import smoke OK.
- End-to-end on real captures: async (thread-offloaded) `load_file`, streaming CSV/JSON export, `find_file_access`, and truncated-XML → raises + no cache file.

No breaking API changes. Version → **0.4.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)